### PR TITLE
Removed precise from supported distros as it wasn't available

### DIFF
--- a/source/installation/apt_repo.rst
+++ b/source/installation/apt_repo.rst
@@ -14,7 +14,6 @@ Supported Releases:
 
 * Ubuntu:
 
- * 12.04LTS (precise)
  * 14.04LTS (trusty)
  * 14.10 (utopic)
  * 15.04 (vivid)


### PR DESCRIPTION
for this release