### PR TITLE
Lowercase/Uppercase fixes on two vault encryption option names

### DIFF
--- a/source/data_at_rest_encryption.rst
+++ b/source/data_at_rest_encryption.rst
@@ -64,13 +64,13 @@ Example:
            - config file
            - Type
          * - vaultServerName
-           - security.vault.ServerName
+           - security.vault.serverName
            - string
          * - vaultPort
            - security.vault.port
            - int
          * - vaultTokenFile
-           - security.vault.secret
+           - security.vault.tokenFile
            - string
          * - vaultSecret
            - security.vault.secret


### PR DESCRIPTION
This patch should be applied to v3.6 and v4.0 branches too.