### PR TITLE
PSMDB-717 Remove first available version for Vault integration

### DIFF
--- a/source/data_at_rest_encryption.rst
+++ b/source/data_at_rest_encryption.rst
@@ -22,8 +22,8 @@ services.
 
 .. rubric:: |vault| Integration
 
-Starting from version 4.0.10, |PSMDB| provides |vault| integration. We only support the |vault|
-backend with KV Secrets Engine - Version 2 (API)
+|PSMDB| is integrated with |vault|. We only support the |vault|
+back end with KV Secrets Engine - Version 2 (API)
 with versioning enabled.
 
 Note that vault secrets path format must be:


### PR DESCRIPTION
Vault integration is available in 3.6.13 and 4.0.10 released in June 2019. PSMDB 4.4 is released in August 2020 which means Vault is available there out of the box.