### PR TITLE
PSMDB-712-Removed connection pool limitation

### DIFF
--- a/source/authentication.rst
+++ b/source/authentication.rst
@@ -320,9 +320,6 @@ This feature has been supported in |mongodb-e| since its version 3.4.
   
 Note the following limitations of |ldap-authorization| in |psmdb|:
   
-- The |abbr.ldap| `connection pool and all related parameters are
-  not supported
-  <https://docs.mongodb.com/manual/core/security-ldap-external/#connection-pool>`_.
 - The `ldapTimeoutMS
   <https://docs.mongodb.com/manual/reference/program/mongoldap/#cmdoption-mongoldap-ldaptimeoutms>`_
   parameter is ignored.


### PR DESCRIPTION
The connection pool supports was added, thus removed this liitation from the list for LDAP authorization