### PR TITLE
Fix CentOS name

### DIFF
--- a/source/install/tarball.rst
+++ b/source/install/tarball.rst
@@ -8,8 +8,8 @@ You can find links to the binary tarball under the *Generic Linux* menu item on 
 
 There are two tarballs available:
 
-- ``percona-server-mongodb-4.0.20-14-x86_64.glibc2.17.tar.gz`` is the general tarball, compatible with any operation system but for Centos 6.
-- ``percona-server-mongodb-4.0.20-14-x86_64.glibc2.12.tar.gz`` is the tarball for Centos 6.  
+- ``percona-server-mongodb-4.0.20-14-x86_64.glibc2.17.tar.gz`` is the general tarball, compatible with any `supported operating system <https://www.percona.com/services/policies/percona-software-support-lifecycle#mongodb>`_ except CentOS 6
+- ``percona-server-mongodb-4.0.20-14-x86_64.glibc2.12.tar.gz`` is the tarball for CentOS 6.  
 
 1. Fetch and extract the correct binary tarball. For example, if you
    are running Debian 10 ("buster"):


### PR DESCRIPTION
Fixed CentOS name
Fixed operating system wording

modified:   source/install/tarball.rst