### PR TITLE
PSMDB-1262 Added EOL label for 4.2 docs

### DIFF
--- a/_resource/overrides/main.html
+++ b/_resource/overrides/main.html
@@ -45,6 +45,10 @@
               <!-- End Google Tag Manager (noscript) -->
               {% endblock %}
 
+             {% block outdated %}
+              <div>This documentation is for the end of life version of Percona Server for MongoDB 4.2 which is no longer supported. <br><strong><a href="https://www.percona.com/blog/mongodb-4-2-eol-implications/">Learn more about MongoDB 4.2 end of life implications</a>.</strong> See the <strong><a href= {{ '../' ~ base_url }}>current documentation</a></strong>. </div>
+             {% endblock %}
+
              {% block content %}
 
               {{ page.content }}

--- a/docs/css/percona.css
+++ b/docs/css/percona.css
@@ -41,6 +41,10 @@ line-height: 1.4;
 margin: 1em 0 .54em;
 }
 
+.md-banner--warning {
+--md-warning-bg-color: #F0B336;
+--md-warning-fg-color: black;
+}
 
 
 /*.git-revision-date-localized-plugin:before {


### PR DESCRIPTION
<img width="1381" alt="Screenshot 2023-05-15 at 12 23 58" src="https://github.com/percona/psmdb-docs/assets/60600800/c489c161-37d7-4ff6-81ac-bb40b8ba2712">
Preview of the changes