### PR TITLE
PSMDB-1573 Update documentation to add guidance on LDAP parameters en…

### DIFF
--- a/docs/authorization.md
+++ b/docs/authorization.md
@@ -61,14 +61,16 @@ So having an array of documents, Percona Server for MongoDB tries to match each 
 
 ### Escaping special characters in usernames
 
-A username can contain special characters in any of its parts. An example of a special character is the `@` sign in an email. 
+A username can contain special characters in any of its parts. A special character is any character which is not alphanumeric and not an ASCII character. 
 
 These characters must be escaped to formulate the correct LDAP query on the following stages: 
-
-* To search for the user in the LDAP server whose username is the LDAP distinguished name. 
+ 
 * To transform a username to the LDAP DN, and the matched pattern of a username must be first queried in the LDAP server to become the DN.
+* To retrieve the groups a user is the member of.
 
 Additionally, the username pattern to match for the transformation can have special characters that must be escaped too.
+
+What exactly characters require escaping depends on the Percona Server for MongoDB configuration. Namely, on the configuration of the LDAP query template and the regular expressions inside the `--ldapUserToDNMapping` parameter.
 
 The escaping rules are described in the following documents:
 
@@ -81,7 +83,7 @@ Their explanation is out of the scope of the Percona Server For MongoDB document
 To summarize, username escaping happens in the following cases:
 
 * When a username is defined as the LDAP DN and has special characters in any of its parts. 
-* When a username must be transformed to the LDAP DN and the username pattern for the transportation has special characters
+* When a username must be transformed to the LDAP DN and the username pattern for the transformation has special characters
 * When the transformed LDAP DN value contains special characters in any of its parts. 
 
 

--- a/docs/authorization.md
+++ b/docs/authorization.md
@@ -61,7 +61,7 @@ So having an array of documents, Percona Server for MongoDB tries to match each 
 
 ### Escaping special characters in usernames
 
-A username can contain special characters in any of its parts. A special character is any character which is not alphanumeric and not an ASCII character. 
+A username can contain special characters in any of its parts. A special character is any character which is not alphanumeric or not an ASCII character. 
 
 These characters must be escaped to formulate the correct LDAP query on the following stages: 
  

--- a/docs/authorization.md
+++ b/docs/authorization.md
@@ -43,7 +43,7 @@ The following diagram illustrates the authentication and authorization flow:
 
 ### Username transformation
 
-If clients connect to Percona Server for MongoDB with usernames that are not LDAP DN, these usernames must be converted to the format acceptable by LDAP.
+If clients connect to Percona Server for MongoDB with usernames that are not LDAP DN, these usernames must be transformed to the format acceptable by LDAP.
 
 To achieve this,  the `--ldapUserToDNMapping` parameter is available in Percona Server for MongoDB configuration.
 
@@ -58,6 +58,34 @@ The `--ldapUserToDNMapping` parameter is a JSON string representing an ordered a
 Both `substitution` and `ldapQuery` should contain placeholders to insert parts of the original username – those placeholders are replaced with regular expression submatches found on the `match` stage.
 
 So having an array of documents, Percona Server for MongoDB tries to match each document against the provided name and if it matches, the name is replaced either with the substitution string or with the result of the LDAP query.
+
+### Escaping special characters in usernames
+
+A username can contain special characters in any of its parts. An example of a special character is the `@` sign in an email. 
+
+These characters must be escaped to formulate the correct LDAP query on the following stages: 
+
+* To search for the user in the LDAP server whose username is the LDAP distinguished name. 
+* To transform a username to the LDAP DN, and the matched pattern of a username must be first queried in the LDAP server to become the DN.
+
+Additionally, the username pattern to match for the transformation can have special characters that must be escaped too.
+
+The escaping rules are described in the following documents:
+
+* [RFC 4514 | LDAP: Distinguished Names](https://datatracker.ietf.org/doc/html/rfc4514) - Escaping in Distinguished Names 
+* [RFC 4515 | LDAP: String Representation of Search Filters](https://datatracker.ietf.org/doc/html/rfc4515) - LDAP search filters utilize its own escaping mechanism 
+* [RFC 4516 | LDAP: Uniform Resource Locator](https://datatracker.ietf.org/doc/html/rfc4516) - General URL escaping rules. 
+
+Their explanation is out of the scope of the Percona Server For MongoDB documentation. Please review the RFC directly or use your preferred LDAP resource.
+
+To summarize, username escaping happens in the following cases:
+
+* When a username is defined as the LDAP DN and has special characters in any of its parts. 
+* When a username must be transformed to the LDAP DN and the username pattern for the transportation has special characters
+* When the transformed LDAP DN value contains special characters in any of its parts. 
+
+
+
 
 ### LDAP referrals
 

--- a/docs/ldap-setup.md
+++ b/docs/ldap-setup.md
@@ -5,7 +5,7 @@ This document describes an example configuration of LDAP authentication and auth
 ## Assumptions
 
 * The setup of an LDAP server is out of scope of this document. We assume that you are familiar with the LDAP server schema.
-* An explanation of [RFC4514](https://www.ietf.org/rfc/rfc4514.txt), [RFC4515](https://tools.ietf.org/html/rfc4515), [RFC4516](https://tools.ietf.org/html/rfc4516), or LDAP queries is out of scope. Please review the RFC directly or use your preferred LDAP resource.
+* An explanation of [RFC4514](https://www.ietf.org/rfc/rfc4514.txt), [RFC4515](https://tools.ietf.org/html/rfc4515), [RFC4516](https://tools.ietf.org/html/rfc4516), or LDAP queries is out of scope of this setup. Please review the RFC directly or use your preferred LDAP resource.
 * You have the LDAP server up and running and it is accessible to the servers with Percona Server for MongoDB installed.
 * This document primarily focuses on OpenLDAP used as the LDAP server and the examples are given based on the OpenLDAP format. If you are using Active Directory, refer to the [Active Directory configuration](#active-directory-configuration) section.
 * In examples below, we use anonymous binds to the LDAP server and the following OpenLDAP groups:
@@ -132,11 +132,11 @@ Using the `--ldapUserToDNMapping` configuration parameter allows you to do this.
 
 If you don’t know what the Substitution or LDAP query string should be, please consult with the LDAP administrators to figure this out.
 
-Not, you can use only the `LDAP query` or the `Substitution` stage, the combination of two is not allowed.
+Note that you can use only the `LDAP query` or the `Substitution` stage, and you cannot combine the two.
 
 ??? tip admonition "Escaping special characters"
     **`substitution` parameter**<br />
-    The result of the substitution becomes the value of the `{USER}` placeholder, which is a `{USER}` value in the `security.ldap.authz.queryTemplate` parameter. Escaping requirements depend on the part of the query template that will be substituted. For example, the result of substitution will be full or part of a distinguished name. According to [RFC4514](https://www.ietf.org/rfc/rfc4514.txt), you must escape special characters in the `substitution` parameter. Using other escaping mechanisms in this parameter is unnecessary because {{ product.psmdb_full_name }} applies the necessary escaping as outlined in [RFC4515](https://tools.ietf.org/html/rfc4515) and [RFC4516](https://tools.ietf.org/html/rfc4516) while substituting the `security.ldap.authz.queryTemplate` parameter.<br />
+    The result of the substitution becomes the value of the `{USER}` placeholder, which is a `{USER}` value in the `security.ldap.authz.queryTemplate` parameter. Escaping requirements depend on the part of the query template that will be substituted. For example, the result of substitution can be full distinguished name or part of it. In this case according to [RFC4514](https://www.ietf.org/rfc/rfc4514.txt), you must escape special characters in the `substitution` parameter. Using other escaping mechanisms in this parameter is unnecessary because {{ product.psmdb_full_name }} applies the necessary escaping as outlined in [RFC4515](https://tools.ietf.org/html/rfc4515) and [RFC4516](https://tools.ietf.org/html/rfc4516) while substituting the `security.ldap.authz.queryTemplate` parameter.<br />
     **`ldapQuery` and `queryTemplate` parameters**<br />
     To properly escape special characters, follow these steps:<br />
     1. Escape special characters in full or partially distinguished names in the query according to [RFC 4514](https://www.ietf.org/rfc/rfc4514.txt).<br />

--- a/docs/ldap-setup.md
+++ b/docs/ldap-setup.md
@@ -5,7 +5,7 @@ This document describes an example configuration of LDAP authentication and auth
 ## Assumptions
 
 * The setup of an LDAP server is out of scope of this document. We assume that you are familiar with the LDAP server schema.
-* If usernames contain special characters, they must be escaped as described in [RFC4514](https://www.ietf.org/rfc/rfc4514.txt), [RFC4515](https://tools.ietf.org/html/rfc4515), [RFC4516](https://tools.ietf.org/html/rfc4516). An explanation of escaping rules or LDAP queries is out of scope of this setup. Please review the RFC directly or use your preferred LDAP resource.
+* If usernames contain special characters, they must be escaped as described in [RFC4514](https://www.ietf.org/rfc/rfc4514.txt), [RFC4515](https://tools.ietf.org/html/rfc4515), [RFC4516](https://tools.ietf.org/html/rfc4516). The usage of particular escaping rules depends on  the part of the LDAP query which will contain the substituted value. An explanation of escaping rules or LDAP queries is out of scope of this setup. Please review the RFC directly or use your preferred LDAP resource.
 * You have the LDAP server up and running and it's accessible to the servers with Percona Server for MongoDB installed.
 * This document primarily focuses on OpenLDAP used as the LDAP server and the examples are given based on the OpenLDAP format. If you are using Active Directory, refer to the [Active Directory configuration](#active-directory-configuration) section.
 * In examples below, we use anonymous binds to the LDAP server and the following OpenLDAP groups:

--- a/docs/ldap-setup.md
+++ b/docs/ldap-setup.md
@@ -128,7 +128,7 @@ This section assumes that users connect to Percona Server for MongoDB by providi
 
 #### Access with username transformation
 
-If users connect to Percona Server for MongoDB with usernames that are not LDAP, you need to transform these usernames to be accepted by the LDAP server. f usernames contain special characters, these [characters must be escaped](#escaping-special-characters). 
+If users connect to Percona Server for MongoDB with usernames that are not LDAP, you need to transform these usernames to be accepted by the LDAP server. If usernames contain special characters, these [characters must be escaped](#escaping-special-characters). 
 
 Using the `--ldapUserToDNMapping` configuration parameter allows you to do this. You specify the match pattern as a regexp to capture a username. Next, specify how to transform it - either to use a substitution value or to query the LDAP server for a username.
 

--- a/docs/ldap-setup.md
+++ b/docs/ldap-setup.md
@@ -4,20 +4,11 @@ This document describes an example configuration of LDAP authentication and auth
 
 ## Assumptions
 
-1. The setup of an LDAP server is out of scope of this document. We assume that you are familiar with the LDAP server schema.
-
-2. You have the LDAP server up and running and it is accessible to the servers with Percona Server for MongoDB installed.
-
-3. This document primarily focuses on OpenLDAP used as the LDAP server and the examples are given based on the OpenLDAP format. If you are using Active Directory, refer to the [Active Directory configuration](#active-directory-configuration) section.
-
-4. You have the `sudo` privilege to the server with the Percona Server for MongoDB installed.
-
-## Prerequisites
-
-* In this setup we use anonymous binds to the LDAP server. If your LDAP server disallows anonymous binds, create the user that Percona Server for MongoDB will use to connect to and query the LDAP server. Define this user’s credentials for the `security.ldap.bind.queryUser` and `security.ldap.bind.queryPassword`  parameters in the `mongod.conf` configuration file.
-
-
-* In this setup, we use the following OpenLDAP groups:
+* The setup of an LDAP server is out of scope of this document. We assume that you are familiar with the LDAP server schema.
+* An explanation of [RFC4514](https://www.ietf.org/rfc/rfc4514.txt), [RFC4515](https://tools.ietf.org/html/rfc4515), [RFC4516](https://tools.ietf.org/html/rfc4516), or LDAP queries is out of scope. Please review the RFC directly or use your preferred LDAP resource.
+* You have the LDAP server up and running and it is accessible to the servers with Percona Server for MongoDB installed.
+* This document primarily focuses on OpenLDAP used as the LDAP server and the examples are given based on the OpenLDAP format. If you are using Active Directory, refer to the [Active Directory configuration](#active-directory-configuration) section.
+* In examples below, we use anonymous binds to the LDAP server and the following OpenLDAP groups:
 
 ```text
 dn: cn=testusers,dc=percona,dc=com
@@ -30,6 +21,12 @@ objectClass: groupOfNames
 cn: otherusers
 member: cn=bob,dc=percona,dc=com
 ```
+
+## Prerequisites 
+- To configure LDAP, you must have the `sudo` privilege to the server with the {{ product.psmdb_full_name }} installed.
+- If your LDAP server disallows anonymous binds, create the user that Percona Server for MongoDB will use to connect to and query the LDAP server. Afterwards, set that username and password using`security.ldap.bind.queryUser` and `security.ldap.bind.queryPassword` parameters in the `mongod.conf` configuration file. If username or any part of it will end up substituted as distinguished name it must be escaped according to [RFC 4514](https://tools.ietf.org/html/rfc4514). It may happen when: 
+    - A username is a fully distinguished name and can be substituted directly into the `security.ldap.authz.queryTemplate` parameter without using any transformation via `security.ldap.userToDNMapping`.
+    - A username represents an email address or fullname and after transformation via `security.ldap.userToDNMapping` some parts of it may become part of distinguished name substituted into the  `security.ldap.authz.queryTemplate` parameter.
 
 ## Setup procedure
 
@@ -129,13 +126,23 @@ This section assumes that users connect to Percona Server for MongoDB by providi
 
 #### Access with username transformation
 
-If users connect to Percona Server for MongoDB with usernames that are not LDAP , you need to transform these usernames to be accepted by the LDAP server.
+If users connect to Percona Server for MongoDB with usernames that are not LDAP, you need to transform these usernames to be accepted by the LDAP server.
 
 Using the `--ldapUserToDNMapping` configuration parameter allows you to do this. You specify the match pattern as a regexp to capture a username. Next, specify how to transform it - either to use a substitution value or to query the LDAP server for a username.
 
-If you don’t know what the substitution or LDAP query string should be, please consult with the LDAP administrators to figure this out.
+If you don’t know what the Substitution or LDAP query string should be, please consult with the LDAP administrators to figure this out.
 
-Note that you can use only the `query` or the `substitution` stage, the combination of two is not allowed.
+Not, you can use only the `LDAP query` or the `Substitution` stage, the combination of two is not allowed.
+
+??? tip admonition "Escaping special characters"
+    **`substitution` parameter**<br />
+    The result of the substitution becomes the value of the `{USER}` placeholder, which is a `{USER}` value in the `security.ldap.authz.queryTemplate` parameter. Escaping requirements depend on the part of the query template that will be substituted. For example, the result of substitution will be full or part of a distinguished name. According to [RFC4514](https://www.ietf.org/rfc/rfc4514.txt), you must escape special characters in the `substitution` parameter. Using other escaping mechanisms in this parameter is unnecessary because {{ product.psmdb_full_name }} applies the necessary escaping as outlined in [RFC4515](https://tools.ietf.org/html/rfc4515) and [RFC4516](https://tools.ietf.org/html/rfc4516) while substituting the `security.ldap.authz.queryTemplate` parameter.<br />
+    **`ldapQuery` and `queryTemplate` parameters**<br />
+    To properly escape special characters, follow these steps:<br />
+    1. Escape special characters in full or partially distinguished names in the query according to [RFC 4514](https://www.ietf.org/rfc/rfc4514.txt).<br />
+    2. Next, escape special characters within the LDAP search filter portion of the query, as outlined in [RFC 4515](https://www.ietf.org/rfc/rfc4515.txt).<br />
+    3. Then, escape special characters in the query according to [RFC 4516](https://www.ietf.org/rfc/rfc4516.txt). Note that you do not need to escape question marks if they are being used to separate parts of the query.<br />
+    4. Finally, if you plan to use the result in a YAML configuration file, you may need to escape characters according to the [YAML specification](https://yaml.org/spec/).
 
 === "Substitution"
 
@@ -165,16 +172,16 @@ Note that you can use only the `query` or the `substitution` stage, the combinat
 
          Modify the given example configuration to match your deployment.
 
-     2. Restart the `mongod` service:
+    2. Restart the `mongod` service:
 
-         ```{.bash data-prompt="$"}
-         $ sudo systemctl restart mongod
-         ```  
-     3. Test the access to Percona Server for MongoDB:
+        ```{.bash data-prompt="$"}
+        $ sudo systemctl restart mongod
+        ```  
+    3. Test the access to Percona Server for MongoDB:
 
-         ```{.bash data-prompt="$"}
-         $ mongosh -u "alice@percona.com" -p "secretpwd" --authenticationDatabase '$external' --authenticationMechanism 'PLAIN'
-         ```
+        ```{.bash data-prompt="$"}
+        $ mongosh -u "alice@percona.com" -p "secretpwd" --authenticationDatabase '$external' --authenticationMechanism 'PLAIN'
+        ```
 
 === "LDAP query"
     

--- a/docs/ldap-setup.md
+++ b/docs/ldap-setup.md
@@ -5,28 +5,31 @@ This document describes an example configuration of LDAP authentication and auth
 ## Assumptions
 
 * The setup of an LDAP server is out of scope of this document. We assume that you are familiar with the LDAP server schema.
-* An explanation of [RFC4514](https://www.ietf.org/rfc/rfc4514.txt), [RFC4515](https://tools.ietf.org/html/rfc4515), [RFC4516](https://tools.ietf.org/html/rfc4516), or LDAP queries is out of scope of this setup. Please review the RFC directly or use your preferred LDAP resource.
-* You have the LDAP server up and running and it is accessible to the servers with Percona Server for MongoDB installed.
+* If usernames contain special characters, they must be escaped as described in [RFC4514](https://www.ietf.org/rfc/rfc4514.txt), [RFC4515](https://tools.ietf.org/html/rfc4515), [RFC4516](https://tools.ietf.org/html/rfc4516). An explanation of escaping rules or LDAP queries is out of scope of this setup. Please review the RFC directly or use your preferred LDAP resource.
+* You have the LDAP server up and running and it's accessible to the servers with Percona Server for MongoDB installed.
 * This document primarily focuses on OpenLDAP used as the LDAP server and the examples are given based on the OpenLDAP format. If you are using Active Directory, refer to the [Active Directory configuration](#active-directory-configuration) section.
 * In examples below, we use anonymous binds to the LDAP server and the following OpenLDAP groups:
 
-```text
-dn: cn=testusers,dc=percona,dc=com
-objectClass: groupOfNames
-cn: testusers
-member: cn=alice,dc=percona,dc=com
+   ```text
+   dn: cn=testusers,dc=percona,dc=com
+   objectClass: groupOfNames
+   cn: testusers
+   member: cn=alice,dc=percona,dc=com   
 
-dn: cn=otherusers,dc=percona,dc=com
-objectClass: groupOfNames
-cn: otherusers
-member: cn=bob,dc=percona,dc=com
-```
+   dn: cn=otherusers,dc=percona,dc=com
+   objectClass: groupOfNames
+   cn: otherusers
+   member: cn=bob,dc=percona,dc=com
+   ```
 
 ## Prerequisites 
+
 - To configure LDAP, you must have the `sudo` privilege to the server with the {{ product.psmdb_full_name }} installed.
-- If your LDAP server disallows anonymous binds, create the user that Percona Server for MongoDB will use to connect to and query the LDAP server. Afterwards, set that username and password using`security.ldap.bind.queryUser` and `security.ldap.bind.queryPassword` parameters in the `mongod.conf` configuration file. If username or any part of it will end up substituted as distinguished name it must be escaped according to [RFC 4514](https://tools.ietf.org/html/rfc4514). It may happen when: 
-    - A username is a fully distinguished name and can be substituted directly into the `security.ldap.authz.queryTemplate` parameter without using any transformation via `security.ldap.userToDNMapping`.
-    - A username represents an email address or fullname and after transformation via `security.ldap.userToDNMapping` some parts of it may become part of distinguished name substituted into the  `security.ldap.authz.queryTemplate` parameter.
+
+- If your LDAP server disallows anonymous binds, create the user that Percona Server for MongoDB will use to connect to and query the LDAP server. Afterwards, set that username and password using the `security.ldap.bind.queryUser` and `security.ldap.bind.queryPassword` parameters in the `mongod.conf` configuration file. If the username or any part of it ends up substituted as distinguished name, it must be escaped according to [RFC 4514](https://tools.ietf.org/html/rfc4514). It may happen when: 
+
+    - A username is a fully distinguished name and can be substituted directly into the LDAP query without using any transformation. The LDAP query is defined within the `security.ldap.authz.queryTemplate` configuration parameter.
+    - A username represents an email address or a full name and requires transformation to LDAP DN. The transformation rules are defined via the `security.ldap.userToDNMapping` configuration parameter. After the transformation, some parts of the username may become part of distinguished name substituted into the `security.ldap.authz.queryTemplate` parameter.
 
 ## Setup procedure
 
@@ -37,7 +40,7 @@ By default, Percona Server for MongoDB establishes the TLS connection when bindi
 1. Place the certificate in the `certs` directory. The path to the `certs` directory is:
 
     * On RHEL / derivatives: `/etc/openldap/certs/`
-    * On : Debian / Ubuntu: `/etc/ssl/certs/`
+    * On Debian / Ubuntu: `/etc/ssl/certs/`
 
 2. Specify the path to the certificates in the `ldap.conf` file:
 
@@ -88,8 +91,7 @@ db.createRole(
 
 #### Access without username transformation
 
-This section assumes that users connect to Percona Server for MongoDB by providing their LDAP DN as the username.
-
+This section assumes that users connect to Percona Server for MongoDB by providing their LDAP DN as the username and the LDAP DNs don't contain special characters. Otherwise, you must escape them according to [RFC 4514 | LDAP: Distinguished Names](https://datatracker.ietf.org/doc/html/rfc4514).
 
 1. Edit the Percona Server for MongoDB configuration file (by default, `/etc/mongod.conf`) and specify the following configuration:
 
@@ -126,23 +128,13 @@ This section assumes that users connect to Percona Server for MongoDB by providi
 
 #### Access with username transformation
 
-If users connect to Percona Server for MongoDB with usernames that are not LDAP, you need to transform these usernames to be accepted by the LDAP server.
+If users connect to Percona Server for MongoDB with usernames that are not LDAP, you need to transform these usernames to be accepted by the LDAP server. f usernames contain special characters, these [characters must be escaped](#escaping-special-characters). 
 
 Using the `--ldapUserToDNMapping` configuration parameter allows you to do this. You specify the match pattern as a regexp to capture a username. Next, specify how to transform it - either to use a substitution value or to query the LDAP server for a username.
 
-If you don’t know what the Substitution or LDAP query string should be, please consult with the LDAP administrators to figure this out.
+If you don't know what the Substitution or LDAP query string should be, please consult with the LDAP administrators to figure this out. 
 
 Note that you can use only the `LDAP query` or the `Substitution` stage, and you cannot combine the two.
-
-??? tip admonition "Escaping special characters"
-    **`substitution` parameter**<br />
-    The result of the substitution becomes the value of the `{USER}` placeholder, which is a `{USER}` value in the `security.ldap.authz.queryTemplate` parameter. Escaping requirements depend on the part of the query template that will be substituted. For example, the result of substitution can be full distinguished name or part of it. In this case according to [RFC4514](https://www.ietf.org/rfc/rfc4514.txt), you must escape special characters in the `substitution` parameter. Using other escaping mechanisms in this parameter is unnecessary because {{ product.psmdb_full_name }} applies the necessary escaping as outlined in [RFC4515](https://tools.ietf.org/html/rfc4515) and [RFC4516](https://tools.ietf.org/html/rfc4516) while substituting the `security.ldap.authz.queryTemplate` parameter.<br />
-    **`ldapQuery` and `queryTemplate` parameters**<br />
-    To properly escape special characters, follow these steps:<br />
-    1. Escape special characters in full or partially distinguished names in the query according to [RFC 4514](https://www.ietf.org/rfc/rfc4514.txt).<br />
-    2. Next, escape special characters within the LDAP search filter portion of the query, as outlined in [RFC 4515](https://www.ietf.org/rfc/rfc4515.txt).<br />
-    3. Then, escape special characters in the query according to [RFC 4516](https://www.ietf.org/rfc/rfc4516.txt). Note that you do not need to escape question marks if they are being used to separate parts of the query.<br />
-    4. Finally, if you plan to use the result in a YAML configuration file, you may need to escape characters according to the [YAML specification](https://yaml.org/spec/).
 
 === "Substitution"
 
@@ -222,6 +214,20 @@ Note that you can use only the `LDAP query` or the `Substitution` stage, and you
          ```{.bash data-prompt="$"}
          mongosh -u "alice" -p "secretpwd" --authenticationDatabase '$external' --authenticationMechanism 'PLAIN'
          ```
+#### Escaping special characters
+
+The **`substitution` parameter**
+
+The result of the substitution becomes the value of the `{USER}` placeholder, which is a `{USER}` value in the `security.ldap.authz.queryTemplate` parameter. Escaping requirements depend on the part of the query template that will be substituted. For example, the result of the substitution can be a full distinguished name or a part of it. In this case, according to [RFC4514](https://www.ietf.org/rfc/rfc4514.txt), you must escape special characters in the `substitution` parameter. Using other escaping mechanisms in this parameter is unnecessary because {{ product.psmdb_full_name }} applies the necessary escaping as outlined in [RFC4515](https://tools.ietf.org/html/rfc4515) and [RFC4516](https://tools.ietf.org/html/rfc4516) while substituting the `security.ldap.authz.queryTemplate` parameter.
+
+The **`ldapQuery` and `queryTemplate` parameters**
+
+To properly escape special characters, follow these steps:
+
+1. Escape special characters in full or partially distinguished names in the query according to [RFC 4514](https://www.ietf.org/rfc/rfc4514.txt).
+2. Next, escape special characters within the LDAP search filter portion of the query, as outlined in [RFC 4515](https://www.ietf.org/rfc/rfc4515.txt).
+3. Then, escape special characters in the query according to [RFC 4516](https://www.ietf.org/rfc/rfc4516.txt). Note that you do not need to escape question marks if they are being used to separate parts of the query.<br />
+4. Finally, if you plan to use the result in a YAML configuration file, you may need to escape characters according to the [YAML specification](https://yaml.org/spec/)
 
 ### Active Directory configuration
 
@@ -247,7 +253,8 @@ dn:CN=otherusers,CN=Users,DC=percona,DC=com
 member:CN=bob,CN=Users,DC=otherusers,DC=example,DC=com
 ```
 
-Use one of the given Percona Server for MongoDB configurations for user authentication and authorization in Active Directory:
+Use one of the given Percona Server for MongoDB configurations for user authentication and authorization in Active Directory. Read about [escaping special characters in usernames](#escaping-special-characters) to modify the configuration accordingly.
+
 
 === "No username transformation"
 
@@ -341,7 +348,9 @@ Use one of the given Percona Server for MongoDB configurations for user authenti
          $ mongosh -u "alice" -p "secretpwd" --authenticationDatabase '$external' --authenticationMechanism 'PLAIN'
          ```
 
-Modify one of this example configuration to match your deployment.
+Modify one of this example configuration to match your deployment. 
+
+
 
 !!! admonition ""
     

--- a/docs/release_notes/8.0.4-1.md
+++ b/docs/release_notes/8.0.4-1.md
@@ -1,4 +1,11 @@
-# Percona Server for MongoDB 8.0.4-1 ({{date.8_0_4}}) 
+title: Percona Server for MongoDB release notes version 8.0.4-1
+summary: Get to know all improvements, new features, and bug and security vulnerability fixes in the release
+authors:
+    - Anastasia Alexandrova
+version: 8.0.4-1
+---
+
+# {{ product.psmdb_full_name }} {{ page.meta.version }} ({{date.8_0_4}}) 
 
 [Installation](../install/index.md){.md-button}
 [Upgrade](../install/upgrade-from-70.md){.md-button}

--- a/variables.yml
+++ b/variables.yml
@@ -5,7 +5,9 @@
 release: '8.0.4-1'
 version: '8.0'
 mongosh: '2.3.2'
-
+product:
+  psmdb_full_name:  Percona Server for MongoDB
 date:
   8_0_4 : "2024-12-17"
+  
 


### PR DESCRIPTION
Add documentation based on @igorsol guidance below:

# LDAP documentation refinements
for [Set up LDAP authentication and authorization using NativeLDAP - Percona Server for MongoDB 8.0](https://docs.percona.com/percona-server-for-mongodb/8.0/ldap-setup.html#__tabbed_2_1)

Creating correct LDAP query may require escaping of special characters. Different parts of such query may have different escaping requirements. There are several RFC documents describing escaping for LDAP:

[RFC 4514 | LDAP: Distinguished Names](https://datatracker.ietf.org/doc/html/rfc4514) - escaping in Distinguished Names
[RFC 4515 | LDAP: String Representation of Search Filters](https://datatracker.ietf.org/doc/html/rfc4515) - LDAP search filters utilize its own escaping mechanism
[RFC 4516 | LDAP: Uniform Resource Locator](https://datatracker.ietf.org/doc/html/rfc4516) - based on general URL escaping. Most obvious example is the need to escape question mark character if it used for something which is not a separator for various parts of LDAP query

There are several parameters in LDAP configuration which require escaping of special characters:
- `security.ldap.authz.queryTemplate` and `ldapQuery` parameter inside `security.ldap.userToDNMapping`
both these parameters are LDAP queries which can contain LDAP search filter and distinguished names. So the correct way to escape special characters is to do it step by step:
1. escape special characters if there are full or partial distinguished names in the query according to RFC 4514
2. after that escape special characters inside LDAP search filter part of the query according to RFC 4515
3. after that escape special characters in the whole query according to RFC 4516. Do not escape question marks if that character is used to separate parts of the query
4. after that if you are going to use result in the YAML config file it might be necessary to do escaping according to [YAML specification](https://yaml.org/spec/)

- `substitution` parameter inside `security.ldap.userToDNMapping`
The result of this substitution becomes the value of the `{USER}` placeholder which is user in the `security.ldap.authz.queryTemplate` parameter. Generally speaking escaping requirements depends on in which part of the query template it will be substituted. For example the most frequent case result of substitution will be full or part of distinguished name. In that case you will need to escape special characters in the `substitution` parameters according to RFC 4514.
It is not necessary to use other escaping mechanisms in this parameter because Percona Server for MongoDB will apply RFC 4515 and RFC 4516 escaping as necessary while making substitutions in the `security.ldap.authz.queryTemplate` parameter.

One more place where you will need to care about special characters is the user name used while connecting using LDAP authorization. In some cases such user name might be full distinguished name and can be substituted directly into the `security.ldap.authz.queryTemplate` parameter without using any transformation via `security.ldap.userToDNMapping`. In other case such user name might represent some user ID such as email or user's real name but after transformation via `security.ldap.userToDNMapping` some parts of it may become part of distinguished name substituted into the  `security.ldap.authz.queryTemplate` parameter. In any case general rule is: if user name or any part of it will end up substituted as distinguished name it must be escaped according to RFC 4514.

MongoDB documentation has following note in several places:

> An explanation of [RFC4514](https://www.ietf.org/rfc/rfc4514.txt), [RFC4515](https://tools.ietf.org/html/rfc4515), [RFC4516](https://tools.ietf.org/html/rfc4516), or LDAP queries is out of scope for the MongoDB Documentation. Please review the RFC directly or use your preferred LDAP resource.

Reference:
[Self-Managed Configuration File Options - security.ldap.userToDNMapping](https://www.mongodb.com/docs/manual/reference/configuration-options/#mongodb-setting-security.ldap.userToDNMapping)