### PR TITLE
PSMDB-1624-fix-user-and-group-for-kerberos-config

### DIFF
--- a/docs/kerberos.md
+++ b/docs/kerberos.md
@@ -4,7 +4,7 @@ This document provides configuration steps for setting up [Kerberos Authenticati
 
 ## Assumptions
 
-The setup of the Kerberos server itself is outside the scope of this document. Please refer to the [Kerberos documentation](https://web.mit.edu/kerberos/krb5-latest/doc/admin/install_kdc.html) for the installation and configuration steps relevant to your operating system.
+The setup of the Kerberos server itself is not included in this document. Please refer to the [Kerberos documentation](https://web.mit.edu/kerberos/krb5-latest/doc/admin/install_kdc.html) for the installation and configuration steps relevant to your operating system.
 
 We assume that you have successfully completed the following steps:
 
@@ -18,7 +18,7 @@ We assume that you have successfully completed the following steps:
 
 ## Add user principals to Percona Server for MongoDB
 
-To authenticate, users must exist in the Kerberos and Percona Server for MongoDB servers with names that match exactly.
+To authenticate, users must exist in the Kerberos and Percona Server for MongoDB servers. Their usernames must match exactly.
 
 After you have defined the user principals in the Kerberos server, add them to the `$external` database in Percona Server for MongoDB and assign required roles:
 

--- a/docs/kerberos.md
+++ b/docs/kerberos.md
@@ -4,7 +4,7 @@ This document provides configuration steps for setting up [Kerberos Authenticati
 
 ## Assumptions
 
-The setup of the Kerberos server itself is out of scope of this document. Please refer to the [Kerberos documentation](https://web.mit.edu/kerberos/krb5-latest/doc/admin/install_kdc.html) for the installation and configuration steps relevant to your operation system.
+The setup of the Kerberos server itself is outside the scope of this document. Please refer to the [Kerberos documentation](https://web.mit.edu/kerberos/krb5-latest/doc/admin/install_kdc.html) for the installation and configuration steps relevant to your operating system.
 
 We assume that you have successfully completed the following steps:
 
@@ -12,15 +12,15 @@ We assume that you have successfully completed the following steps:
 
 * Added necessary [realms](https://web.mit.edu/kerberos/krb5-1.12/doc/admin/realm_config.html)
 
-* Added service, admin and user [principals](https://web.mit.edu/kerberos/krb5-1.5/krb5-1.5.4/doc/krb5-user/What-is-a-Kerberos-Principal_003f.html#What-is-a-Kerberos-Principal_003f)
+* Added service, admin, and user [principals](https://web.mit.edu/kerberos/krb5-1.5/krb5-1.5.4/doc/krb5-user/What-is-a-Kerberos-Principal_003f.html#What-is-a-Kerberos-Principal_003f)
 
 * Configured the `A` and `PTR` DNS records for every host running `mongod` instance to resolve the hostnames onto Kerberos realm.
 
 ## Add user principals to Percona Server for MongoDB
 
-To get authenticated, users must exist both in the Kerberos and Percona Server for MongoDB servers with exactly matching names.
+To authenticate, users must exist in the Kerberos and Percona Server for MongoDB servers with names that match exactly.
 
-After you defined the user principals in the Kerberos server, add them to the `$external` database in Percona Server for MongoDB and assign required roles:
+After you have defined the user principals in the Kerberos server, add them to the `$external` database in Percona Server for MongoDB and assign required roles:
 
 ```{.javascript data-prompt=">"}
 > use $external
@@ -29,13 +29,13 @@ After you defined the user principals in the Kerberos server, add them to the `$
 
 Replace `demo@PERCONATEST.COM` with your username and Kerberos realm.
 
-## Configure Kerberos keytab files
+## Configure Kerberos `keytab` files
 
-A keytab file stores the authentication keys for a service principal representing a `mongod` instance to access the Kerberos admin server.
+A `keytab` file stores the authentication keys for a service principal representing a `mongod` instance to access the Kerberos admin server.
 
-After you have added the service principal to the Kerberos admin server, the entry for this principal is added to the `/etc/krb5.keytab` keytab file.
+After you have added the service principal to the Kerberos admin server, the entry for this principal is added to the `/etc/krb5.keytab` file.
 
-The `mongod` server must have access to the keytab file to authenticate. To keep the keytab file secure, restrict the access to it only for the user running the `mongod` process.
+To authenticate, the `mongod` server must have access to the `keytab` file. To keep the `keytab` file secure, restrict access to it only to the user running the `mongod` process.
 
 
 1. Stop the `mongod` service
@@ -44,16 +44,16 @@ The `mongod` server must have access to the keytab file to authenticate. To keep
     $ sudo systemctl stop mongod
     ```
 
-2. [Generate the keytab file](https://web.mit.edu/kerberos/krb5-1.5/krb5-1.5.4/doc/krb5-install/The-Keytab-File.html) or get a copy of it if you generated the keytab file on another host. Save the keyfile under a separate path (e.g. `/etc/mongodb.keytab`)
+2. [Generate the keytab file](https://web.mit.edu/kerberos/krb5-1.5/krb5-1.5.4/doc/krb5-install/The-Keytab-File.html) or get a copy of it if you generated the `keytab` file on another host. Save the key file under a separate path (e.g. `/etc/mongodb.keytab`)
 
     ```{.bash data-prompt="$"}
     $ cp /etc/krb5.keytab /etc/mongodb.keytab
     ```
 
-3. Change the ownership to the keytab file
+3. Change the ownership to the `keytab` file
 
     ```{.bash data-prompt="$"}
-    $ sudo chown mongod:mongod /etc/mongodb.keytab
+    $ sudo chown mongodb:mongodb /etc/mongodb.keytab
     ```
 
 4. Set the `KRB5_KTNAME` variable in the environment file for the `mongod` process.


### PR DESCRIPTION
PSMDB-1624 Fix default username and group name when setting ownership for kerberos keytab file