### PR TITLE
Specify that the needed edition for the FCBIS functionality is PRO

### DIFF
--- a/docs/fcbis.md
+++ b/docs/fcbis.md
@@ -7,7 +7,7 @@
 
 When a new member joins the replica set, it receives the data from the existing replica set node via the initial sync. 
 
-In [Percona Server for MongoDB Pro](psmdb-pro.md), you can choose a file copy-based initial sync for a new node. You must have WiredTiger defined as the storage.
+In Percona Server for MongoDB Pro, you can choose a file copy-based initial sync for a new node. You must have WiredTiger defined as the storage.
 
 The file copy-based initial sync method is a physical copying of the data files from the source to the target. It is much faster than the default [logical initial sync :octicons-link-external-16:](https://www.mongodb.com/docs/manual/core/replica-set-sync/#logical-initial-sync-process) for big datasets (500GB+), which is especially beneficial in heavy write environments. Using this initial sync method speeds up cluster scaling and increases restore performance. 
 

--- a/docs/fcbis.md
+++ b/docs/fcbis.md
@@ -1,14 +1,14 @@
 # File copy based initial sync
 
-!!! admonition "Version added: [7.0.22-12](release_notes/7.0.22-12.md)"
+!!! admonition "Version added: [7.0.22-12](release_notes/7.0.22-12.md) [Pro](psmdb-pro.md)"
 
 When a new member joins the replica set, it receives the data from the existing replica set node via the initial sync. 
 
-In Percona Server for MongoDB, you can choose a file copy-based initial sync for a new node. You must have WiredTiger defined as the storage.
+In [Percona Server for MongoDB Pro](psmdb-pro.md), you can choose a file copy-based initial sync for a new node. You must have WiredTiger defined as the storage.
 
 The file copy-based initial sync method is a physical copying of the data files from the source to the target. It is much faster than the default [logical initial sync :octicons-link-external-16:](https://www.mongodb.com/docs/manual/core/replica-set-sync/#logical-initial-sync-process) for big datasets (500GB+), which is especially beneficial in heavy write environments. Using this initial sync method speeds up cluster scaling and increases restore performance. 
 
-File copy-based initial sync implementation is compatible with that of MongoDB Enterprise Advanced and has the same [configuration parameters](#configuration-parameters).
+File copy-based initial sync implementation is compatible with that of MongoDB Enterprise Advanced and has the same [configuration parameters](#configuration-parameters). It is available in [Percona Server for MongoDB Pro](psmdb-pro.md) out of the box starting with version 7.0.22-12. You can also receive this functionality by [building Percona Server for MongoDB from source code](install/source.md).
 
 To select the initial sync method, specify the `initialSyncMethod` parameter in the configuration file for the target node:
 

--- a/docs/fcbis.md
+++ b/docs/fcbis.md
@@ -1,6 +1,9 @@
 # File copy based initial sync
 
-!!! admonition "Version added: [7.0.22-12](release_notes/7.0.22-12.md) [Pro](psmdb-pro.md)"
+!!! admonition "Version added: [7.0.22-12](release_notes/7.0.22-12.md)"
+    
+    Available in [Percona Server for MongoDB Pro](psmdb-pro.md) out of the box. 
+
 
 When a new member joins the replica set, it receives the data from the existing replica set node via the initial sync. 
 

--- a/docs/fcbis.md
+++ b/docs/fcbis.md
@@ -7,7 +7,7 @@
 
 When a new member joins the replica set, it receives the data from the existing replica set node via the initial sync. 
 
-In Percona Server for MongoDB Pro, you can choose a file copy-based initial sync for a new node. You must have WiredTiger defined as the storage.
+In Percona Server for MongoDB, you can choose a file copy-based initial sync for a new node. You must have WiredTiger defined as the storage.
 
 The file copy-based initial sync method is a physical copying of the data files from the source to the target. It is much faster than the default [logical initial sync :octicons-link-external-16:](https://www.mongodb.com/docs/manual/core/replica-set-sync/#logical-initial-sync-process) for big datasets (500GB+), which is especially beneficial in heavy write environments. Using this initial sync method speeds up cluster scaling and increases restore performance. 
 


### PR DESCRIPTION
It is important to mention that the needed edition for the FCBIS functinality is PRO, otherwise it is not clear if one starts reading directly from https://docs.percona.com/percona-server-for-mongodb/7.0/fcbis.html.

I implemented the text it in a similar way we did in https://docs.percona.com/percona-server-for-mongodb/7.0/fips.html

Thanks!