### PR TITLE
7.0 PSMDB-1893-Disable-specific-FTDC-metric-groups

### DIFF
--- a/docs/set-parameter.md
+++ b/docs/set-parameter.md
@@ -100,6 +100,11 @@ See what parameters you can define in the [parameters list](https://www.mongodb.
 | Mode                          | Metrics Collected                                                                 | Risks / Overhead                                                                 |
 |------------------------------|------------------------------------------------------------------------------------|----------------------------------------------------------------------------------|
 | **Default (no tuning)**      | `systemMetrics` (disks and mounts), `serverStatus.connections`, `replSetGetStatus`, plus all other FTDC groups | Full visibility, but it may lead to increased noise and can become unresponsive in FUSE, autofs, or NFS environments. |
+<<<<<<< Updated upstream
 | **Disable disks only** | All FTDC groups, with `systemMetrics` excluding **disk-level stats** | Reduces overhead while retaining mount-level visibility.|
 | **Disable mounts only** | All FTDC groups, with `systemMetrics` excluding **mount-level stats** | Avoids interruptions from unresponsive mounts while continuing to collect disk-level statistics.|
+=======
+| **Disable disks only** | All FTDC groups, with `systemMetrics`  excluding **disk-level stats** | Reduces overhead while retaining mount-level visibility.|
+| **Disable mounts only**   | All FTDC groups, with `systemMetrics` excluding **mount-level stats**| Avoids interruptions from unresponsive mounts while while retaining disk-level visibility.|
+>>>>>>> Stashed changes
 

--- a/docs/set-parameter.md
+++ b/docs/set-parameter.md
@@ -1,7 +1,33 @@
 # Percona Server for MongoDB parameter tuning guide
 
-Percona Server for MongoDB includes several parameters that can be changed
-in one of the following ways:
+## Disable FTDC metric groups
+
+### Overview
+
+FTDC collects diagnostic samples such as `serverStatus`, `replSetGetStatus`, and Operating System level `systemMetrics`. By default, `systemMetrics` are collected in all environments. This can create significant noise and overhead, as disk and mount statistics are gathered from every available mount point.
+
+When using FUSE, autofs, or NFS, reading disk stats from an unresponsive mount may cause the FTDC thread to enter an **uninterruptible sleep (D-state)**, halting all FTDC sampling until the node is restarted. To prevent this issue, you can disable specific subsections of `systemMetrics` while still collecting all other essential metrics.
+
+### Parameters
+
+Two new server parameters control the collection of disks and mounts subsections within `systemMetrics` in FTDC:
+
+- **diagnosticDataCollectionEnableSystemMetricsDisks**
+    - Enables or disables collection of disk-level statistics.
+    - Type: Boolean (`true`/`false`)
+    - Default: `true` (enabled)
+    - Scope: Startup; runtime configurable via `setParameter`
+
+- **diagnosticDataCollectionEnableSystemMetricsMounts**
+    - Enables or disables collection of mount-level statistics.
+    - Type: Boolean (`true`/`false`)
+    - Default: `true` (enabled)
+    - Scope: Startup; runtime configurable via `setParameter`
+
+
+## Configuration Methods
+
+Percona Server for MongoDB includes several parameters that can be changed in one of the following ways:
 
 === ":octicons-file-code-24: Configuration file"
 
@@ -12,7 +38,18 @@ in one of the following ways:
     setParameter:
       <parameter>: <value>
     ```
+      
+    ??? example "Example: diagnosticDataCollectionEnableSystemMetricsDisks set to true"
+        ```yaml
+        setParameter:
+          diagnosticDataCollectionEnableSystemMetricsDisks: true
+        ```
 
+    ??? example "Example: diagnosticDataCollectionEnableSystemMetricsMounts set to false"
+        ```yaml
+        setParameter:
+          diagnosticDataCollectionEnableSystemMetricsMounts: false
+        ```
 
 === ":material-console: Command line"
 
@@ -24,15 +61,46 @@ in one of the following ways:
       --setParameter <parameter>=<value>\
     ```
 
+    ??? example "Example: diagnosticDataCollectionEnableSystemMetricsDisks set to false"
+        ```bash
+        mongod \
+          --setParameter diagnosticDataCollectionEnableSystemMetricsDisks=false
+        ```
+
+    ??? example "Example: diagnosticDataCollectionEnableSystemMetricsMounts set to true"
+        ```bash
+        mongod \
+          --setParameter diagnosticDataCollectionEnableSystemMetricsMounts=true
+        ```
+
 === ":simple-mongodb: `setParameter` command"    
 
     Use the `setParameter` command on the `admin` database
     to make changes at runtime:    
 
-    ```{.javascript data-prompt=">"}
-    > db = db.getSiblingDB('admin')
-    > db.runCommand( { setParameter: 1, <parameter>: <value> } )
+    ```javascript
+    db = db.getSiblingDB('admin')
+    db.runCommand( { setParameter: 1, <parameter>: <value> } )
     ```
 
-See what parameters you can define in the [parameters list](https://www.mongodb.com/docs/v7.0/reference/parameters/#parameters).
+    ??? example "Example: diagnosticDataCollectionEnableSystemMetricsDisks set to true"
+        ```javascript
+        db.adminCommand({setParameter: 1, diagnosticDataCollectionEnableSystemMetricsDisks: true})
+        ```
+
+    ??? example "Example: diagnosticDataCollectionEnableSystemMetricsMounts set to false"
+        ```javascript
+        db.adminCommand({setParameter: 1, diagnosticDataCollectionEnableSystemMetricsMounts: false})
+        ```
+
+See what parameters you can define in the [parameters list](https://www.mongodb.com/docs/v8.0/reference/parameters/#parameters).
+
+
+## Comparison: Default vs. tuned FTDC behavior
+
+| Mode                          | Metrics Collected                                                                 | Risks / Overhead                                                                 |
+|------------------------------|------------------------------------------------------------------------------------|----------------------------------------------------------------------------------|
+| **Default (no tuning)**      | `systemMetrics` (disks and mounts), `serverStatus.connections`, `replSetGetStatus`, plus all other FTDC groups | Full visibility, but it may lead to increased noise and can become unresponsive in FUSE, autofs, or NFS environments. |
+| **Disable disks only** | All FTDC groups, with `systemMetrics`  excluding **disk-level stats** | Reduces overhead while retaining mount-level visibility.|
+| **Disable mounts only**   | All FTDC groups, with `systemMetrics` excluding **mount-level stats**| Avoids interruptions from unresponsive mounts while continuing to collect disk-level statistics.|
 

--- a/docs/set-parameter.md
+++ b/docs/set-parameter.md
@@ -107,6 +107,9 @@ See what parameters you can define in the [parameters list](https://www.mongodb.
 | **Disable disks only** | All FTDC groups, with `systemMetrics`  excluding **disk-level stats** | Reduces overhead while retaining mount-level visibility.|
 | **Disable mounts only**   | All FTDC groups, with `systemMetrics` excluding **mount-level stats**| Avoids interruptions from unresponsive mounts while while retaining disk-level visibility.|
 <<<<<<< Updated upstream
+<<<<<<< Updated upstream
+>>>>>>> Stashed changes
+=======
 >>>>>>> Stashed changes
 =======
 >>>>>>> Stashed changes

--- a/docs/set-parameter.md
+++ b/docs/set-parameter.md
@@ -37,7 +37,6 @@ Percona Server for MongoDB includes several parameters that can be changed in on
     setParameter:
       <parameter>: <value>
     ```
-      
     ??? example "Example: diagnosticDataCollectionEnableSystemMetricsDisks set to true"
         ```yaml
         setParameter:

--- a/docs/set-parameter.md
+++ b/docs/set-parameter.md
@@ -99,7 +99,7 @@ See what parameters you can define in the [parameters list](https://www.mongodb.
 
 | Mode                          | Metrics Collected                                                                 | Risks / Overhead                                                                 |
 |------------------------------|------------------------------------------------------------------------------------|----------------------------------------------------------------------------------|
-| **Default (no tuning)**      | `systemMetrics` (disks and mounts), `serverStatus.connections`, `replSetGetStatus`, plus all other FTDC groups | Full visibility, but it may lead to increased noise and can become unresponsive in FUSE, autofs, or NFS environments. |
+| **Default (no tuning)**      | `systemMetrics` (disks and mounts), `serverStatus.connections`, `replSetGetStatus`, plus all other FTDC groups | Provides full visibility, but may lead to increased noise and overhead. FTDC can become unresponsive in FUSE, autofs, or NFS environments.|
 | **Disable disks only** | All FTDC groups, with `systemMetrics`  excluding **disk-level stats** | Reduces overhead while retaining mount-level visibility.|
 | **Disable mounts only**   | All FTDC groups, with `systemMetrics` excluding **mount-level stats**| Avoids interruptions from unresponsive mounts while while retaining disk-level visibility.|
 

--- a/docs/set-parameter.md
+++ b/docs/set-parameter.md
@@ -24,7 +24,6 @@ Two new server parameters control the collection of disks and mounts subsections
     - Default: `true` (enabled)
     - Scope: Startup; runtime configurable via `setParameter`
 
-
 ## Configuration Methods
 
 Percona Server for MongoDB includes several parameters that can be changed in one of the following ways:

--- a/docs/set-parameter.md
+++ b/docs/set-parameter.md
@@ -100,17 +100,6 @@ See what parameters you can define in the [parameters list](https://www.mongodb.
 | Mode                          | Metrics Collected                                                                 | Risks / Overhead                                                                 |
 |------------------------------|------------------------------------------------------------------------------------|----------------------------------------------------------------------------------|
 | **Default (no tuning)**      | `systemMetrics` (disks and mounts), `serverStatus.connections`, `replSetGetStatus`, plus all other FTDC groups | Full visibility, but it may lead to increased noise and can become unresponsive in FUSE, autofs, or NFS environments. |
-<<<<<<< Updated upstream
-| **Disable disks only** | All FTDC groups, with `systemMetrics` excluding **disk-level stats** | Reduces overhead while retaining mount-level visibility.|
-| **Disable mounts only** | All FTDC groups, with `systemMetrics` excluding **mount-level stats** | Avoids interruptions from unresponsive mounts while continuing to collect disk-level statistics.|
-=======
 | **Disable disks only** | All FTDC groups, with `systemMetrics`  excluding **disk-level stats** | Reduces overhead while retaining mount-level visibility.|
 | **Disable mounts only**   | All FTDC groups, with `systemMetrics` excluding **mount-level stats**| Avoids interruptions from unresponsive mounts while while retaining disk-level visibility.|
-<<<<<<< Updated upstream
-<<<<<<< Updated upstream
->>>>>>> Stashed changes
-=======
->>>>>>> Stashed changes
-=======
->>>>>>> Stashed changes
 

--- a/docs/set-parameter.md
+++ b/docs/set-parameter.md
@@ -98,7 +98,7 @@ See what parameters you can define in the [parameters list](https://www.mongodb.
 
 | Mode                          | Metrics Collected                                                                 | Risks / Overhead                                                                 |
 |------------------------------|------------------------------------------------------------------------------------|----------------------------------------------------------------------------------|
-| **Default (no tuning)**      | `systemMetrics` (disks and mounts), `serverStatus.connections`, `replSetGetStatus`, plus all other FTDC groups | Full visibility, but it may lead to increased noise and can become unresponsive in FUSE, autofs, or NFS environments. |
+| **Default (no tuning)**      | `systemMetrics` (disks and mounts), `serverStatus.connections`, `replSetGetStatus`, plus all other FTDC groups | Provides full visibility, but may lead to increased noise and overhead. FTDC can become unresponsive in FUSE, autofs, or NFS environments. |
 | **Disable disks only** | All FTDC groups, with `systemMetrics`  excluding **disk-level stats** | Reduces overhead while retaining mount-level visibility.|
 | **Disable mounts only**   | All FTDC groups, with `systemMetrics` excluding **mount-level stats**| Avoids interruptions from unresponsive mounts while while retaining disk-level visibility.|
 

--- a/docs/set-parameter.md
+++ b/docs/set-parameter.md
@@ -78,8 +78,7 @@ You can modify parameters in Percona Server for MongoDB using the following meth
     to make changes at runtime:    
 
     ```javascript
-    db = db.getSiblingDB('admin')
-    db.runCommand( { setParameter: 1, <parameter>: <value> } )
+    db.adminCommand( { setParameter: 1, <parameter>: <value> } )
     ```
 
     ??? example "Example: diagnosticDataCollectionEnableSystemMetricsDisks set to true"

--- a/docs/set-parameter.md
+++ b/docs/set-parameter.md
@@ -52,7 +52,7 @@ You can modify parameters in Percona Server for MongoDB using the following meth
 
 === ":material-console: Command line"
 
-    use the `--setParameter` command line option arguments when running the `mongod` process
+    Use the `--setParameter` command line option arguments when running the `mongod` process
     for development or testing purposes:    
 
     ```bash

--- a/docs/set-parameter.md
+++ b/docs/set-parameter.md
@@ -26,7 +26,8 @@ Two new server parameters control the collection of disks and mounts subsections
 
 ## Configuration Methods
 
-Percona Server for MongoDB includes several parameters that can be changed in one of the following ways:
+You can modify parameters in Percona Server for MongoDB using the following methods:
+
 
 === ":octicons-file-code-24: Configuration file"
 

--- a/docs/set-parameter.md
+++ b/docs/set-parameter.md
@@ -95,7 +95,7 @@ You can modify parameters in Percona Server for MongoDB using the following meth
 See what parameters you can define in the [parameters list](https://www.mongodb.com/docs/v7.0/reference/parameters/#parameters).
 
 
-## Comparison: Default vs. tuned FTDC behavior
+## Comparison: default vs. tuned FTDC behavior
 
 | Mode                          | Metrics Collected                                                                 | Risks / Overhead                                                                 |
 |------------------------------|------------------------------------------------------------------------------------|----------------------------------------------------------------------------------|

--- a/docs/set-parameter.md
+++ b/docs/set-parameter.md
@@ -106,5 +106,8 @@ See what parameters you can define in the [parameters list](https://www.mongodb.
 =======
 | **Disable disks only** | All FTDC groups, with `systemMetrics`  excluding **disk-level stats** | Reduces overhead while retaining mount-level visibility.|
 | **Disable mounts only**   | All FTDC groups, with `systemMetrics` excluding **mount-level stats**| Avoids interruptions from unresponsive mounts while while retaining disk-level visibility.|
+<<<<<<< Updated upstream
+>>>>>>> Stashed changes
+=======
 >>>>>>> Stashed changes
 

--- a/docs/set-parameter.md
+++ b/docs/set-parameter.md
@@ -95,7 +95,7 @@ You can modify parameters in Percona Server for MongoDB using the following meth
 See what parameters you can define in the [parameters list](https://www.mongodb.com/docs/v7.0/reference/parameters/#parameters).
 
 
-## Comparison: default vs. tuned FTDC behavior
+## Comparison: Default vs. tuned FTDC behavior
 
 | Mode                          | Metrics Collected                                                                 | Risks / Overhead                                                                 |
 |------------------------------|------------------------------------------------------------------------------------|----------------------------------------------------------------------------------|

--- a/docs/set-parameter.md
+++ b/docs/set-parameter.md
@@ -102,5 +102,5 @@ See what parameters you can define in the [parameters list](https://www.mongodb.
 |------------------------------|------------------------------------------------------------------------------------|----------------------------------------------------------------------------------|
 | **Default (no tuning)**      | `systemMetrics` (disks and mounts), `serverStatus.connections`, `replSetGetStatus`, plus all other FTDC groups | Full visibility, but it may lead to increased noise and can become unresponsive in FUSE, autofs, or NFS environments. |
 | **Disable disks only** | All FTDC groups, with `systemMetrics`  excluding **disk-level stats** | Reduces overhead while retaining mount-level visibility.|
-| **Disable mounts only**   | All FTDC groups, with `systemMetrics` excluding **mount-level stats**| Avoids interruptions from unresponsive mounts while continuing to collect disk-level statistics.|
+| **Disable mounts only** | All FTDC groups, with `systemMetrics` excluding **mount-level stats** | Avoids interruptions from unresponsive mounts while continuing to collect disk-level statistics.|
 

--- a/docs/set-parameter.md
+++ b/docs/set-parameter.md
@@ -24,7 +24,7 @@ Two new server parameters control the collection of disks and mounts subsections
     - Default: `true` (enabled)
     - Scope: Startup; runtime configurable via `setParameter`
 
-## Configuration Methods
+## Configuration methods
 
 You can modify parameters in Percona Server for MongoDB using the following methods:
 

--- a/docs/set-parameter.md
+++ b/docs/set-parameter.md
@@ -100,6 +100,6 @@ See what parameters you can define in the [parameters list](https://www.mongodb.
 | Mode                          | Metrics Collected                                                                 | Risks / Overhead                                                                 |
 |------------------------------|------------------------------------------------------------------------------------|----------------------------------------------------------------------------------|
 | **Default (no tuning)**      | `systemMetrics` (disks and mounts), `serverStatus.connections`, `replSetGetStatus`, plus all other FTDC groups | Full visibility, but it may lead to increased noise and can become unresponsive in FUSE, autofs, or NFS environments. |
-| **Disable disks only** | All FTDC groups, with `systemMetrics`  excluding **disk-level stats** | Reduces overhead while retaining mount-level visibility.|
+| **Disable disks only** | All FTDC groups, with `systemMetrics` excluding **disk-level stats** | Reduces overhead while retaining mount-level visibility.|
 | **Disable mounts only** | All FTDC groups, with `systemMetrics` excluding **mount-level stats** | Avoids interruptions from unresponsive mounts while continuing to collect disk-level statistics.|
 

--- a/docs/set-parameter.md
+++ b/docs/set-parameter.md
@@ -93,7 +93,7 @@ Percona Server for MongoDB includes several parameters that can be changed in on
         db.adminCommand({setParameter: 1, diagnosticDataCollectionEnableSystemMetricsMounts: false})
         ```
 
-See what parameters you can define in the [parameters list](https://www.mongodb.com/docs/v8.0/reference/parameters/#parameters).
+See what parameters you can define in the [parameters list](https://www.mongodb.com/docs/v7.0/reference/parameters/#parameters).
 
 
 ## Comparison: Default vs. tuned FTDC behavior

--- a/docs/set-parameter.md
+++ b/docs/set-parameter.md
@@ -100,5 +100,5 @@ See what parameters you can define in the [parameters list](https://www.mongodb.
 |------------------------------|------------------------------------------------------------------------------------|----------------------------------------------------------------------------------|
 | **Default (no tuning)**      | `systemMetrics` (disks and mounts), `serverStatus.connections`, `replSetGetStatus`, plus all other FTDC groups | Provides full visibility, but may lead to increased noise and overhead. FTDC can become unresponsive in FUSE, autofs, or NFS environments. |
 | **Disable disks only** | All FTDC groups, with `systemMetrics`  excluding **disk-level stats** | Reduces overhead while retaining mount-level visibility.|
-| **Disable mounts only**   | All FTDC groups, with `systemMetrics` excluding **mount-level stats**| Avoids interruptions from unresponsive mounts while while retaining disk-level visibility.|
+| **Disable mounts only**   | All FTDC groups, with `systemMetrics` excluding **mount-level stats**| Avoids interruptions from unresponsive mounts while retaining disk-level visibility.|
 


### PR DESCRIPTION
Create a section to selectively disable FTDC metric groups. For more detailed information, please refer to the following ticket.

https://perconadev.atlassian.net/browse/PSMDB-1893