### PR TITLE
Refine wording on data at rest encryption details

### DIFF
--- a/docs/data-at-rest-encryption.md
+++ b/docs/data-at-rest-encryption.md
@@ -20,11 +20,11 @@ Thus, two types of keys are used for data at rest encryption:
 
 * Database keys to encrypt data. They are stored internally, near the data that they encrypt.
 
-* Master key to encrypt database keys. It is kept separately from the data and database keys and requires external management.
+* The master key to encrypt database keys. It is kept separately from the data and database keys and requires external management.
 
 !!! important
 
-    Each node of a replica set uses the same Master key to encrypt the key database.
+    Each node of a replica set uses the same master key to encrypt the key database.
     
 To manage the master encryption key, use one of the supported key management options:
 

--- a/docs/data-at-rest-encryption.md
+++ b/docs/data-at-rest-encryption.md
@@ -1,8 +1,8 @@
 # Encryption at Rest
 
-Encryption at rest should be used with data in transit encryption and policies that protect accounts, passwords, and encryption keys. When implemented well, encryption at rest helps organizations to comply with security and privacy standards like HIPAA, PCI-DSS, GDPR, and FIPS, ensuring sensitive data is protected both when it's being transmitted and when it's stored.
+Encryption at rest should be used together with data in transit encryption and policies that protect accounts, passwords, and encryption keys. When implemented well, encryption at rest helps organizations comply with security and privacy standards like HIPAA, PCI-DSS, GDPR, and FIPS, ensuring sensitive data is protected both when it's being transmitted and when it's stored.
 
-Data encryption at rest was introduced in Percona Server for MongoDB 3.6 and is fully compatible with MongoDB's encryption interface. Percona Server for MongoDB supports the following Key Management System (KMS) integrations:
+Data encryption at rest was first introduced in Percona Server for MongoDB 3.6 and is fully compatible with MongoDB's encryption interface. Percona Server for MongoDB supports the following Key Management System (KMS) integrations:
 
 * [HashiCorp Vault](vault.md)
 * [OpenBao](openbao.md)
@@ -12,16 +12,20 @@ Data encryption at rest was introduced in Percona Server for MongoDB 3.6 and is 
 
 !!! important
 
-    You can only enable data at rest encryption and provide all encryption settings on an empty database, when you start the `mongod` instance for the first time. You cannot enable or disable encryption while the Percona Server for MongoDB server is already running and / or has some data. Nor can you change the effective encryption mode by simply restarting the server. Every time you restart the server, the encryption settings must be the same.
+    You can only enable data at rest encryption on an empty database, when you start the `mongod` instance for the first time. You cannot enable or disable encryption while the Percona Server for MongoDB server is already running and / or has some data. Nor can you change the effective encryption mode by simply restarting the server. Every time you restart the server, the encryption settings must remain the same.
 
-Each node of Percona Server for MongoDB generates a random, individual key for every database. It encrypts every database with an individual key and puts those keys into the special, so-called key database. Then each node of Percona Server for MongoDB randomly generates a unique master encryption key and encrypts the key database with this key. 
+Percona Server for MongoDB uses a two-level key hierarchy. It encrypts each database with an individual key, and puts those keys into a special, so-called "key database". Then, Percona Server for MongoDB randomly generates a unique master encryption key and encrypts the key database with this key. 
 
 Thus, two types of keys are used for data at rest encryption:
 
 * Database keys to encrypt data. They are stored internally, near the data that they encrypt.
 
-* The master key to encrypt database keys. It is kept separately from the data and database keys and requires external management.
+* Master key to encrypt database keys. It is kept separately from the data and database keys and requires external management.
 
+!!! important
+
+    Each node of a replica set uses the same Master key to encrypt the key database.
+    
 To manage the master encryption key, use one of the supported key management options:
 
 * Integration with an external key server (recommended). Percona Server for MongoDB is [integrated with HashiCorp Vault](vault.md) and [OpenBao](openbao.md) for this purpose. It also supports the secure transfer of keys using [Key Management Interoperability Protocol (KMIP)](kmip.md).

--- a/docs/data-at-rest-encryption.md
+++ b/docs/data-at-rest-encryption.md
@@ -14,7 +14,7 @@ Data encryption at rest was first introduced in Percona Server for MongoDB 3.6 a
 
     You can only enable data at rest encryption on an empty database, when you start the `mongod` instance for the first time. You cannot enable or disable encryption while the Percona Server for MongoDB server is already running and / or has some data. Nor can you change the effective encryption mode by simply restarting the server. Every time you restart the server, the encryption settings must remain the same.
 
-Percona Server for MongoDB uses a two-level key hierarchy. It encrypts each database with an individual key, and puts those keys into a special, so-called "key database". Then, Percona Server for MongoDB randomly generates a unique master encryption key and encrypts the key database with this key. 
+Percona Server for MongoDB uses a two-level key hierarchy. It encrypts each database with an individual key, and puts those keys into a special, so-called "key database". Then, Percona Server for MongoDB uses a master encryption key, provided and managed via the configured key management option, to encrypt the key database. 
 
 Thus, two types of keys are used for data at rest encryption:
 

--- a/docs/data-at-rest-encryption.md
+++ b/docs/data-at-rest-encryption.md
@@ -12,7 +12,7 @@ Data encryption at rest was first introduced in Percona Server for MongoDB 3.6 a
 
 !!! important
 
-    You can only enable data at rest encryption on an empty database, when you start the `mongod` instance for the first time. You cannot enable or disable encryption while the Percona Server for MongoDB server is already running and / or has some data. Nor can you change the effective encryption mode by simply restarting the server. Every time you restart the server, the encryption settings must remain the same.
+    You can only enable data at rest encryption on an empty database when you start the `mongod` instance for the first time. You cannot enable or disable encryption while the Percona Server for MongoDB server is already running and/or has some data. Nor can you change the effective encryption mode by simply restarting the server. Every time you restart the server, the encryption settings must remain the same.
 
 Percona Server for MongoDB uses a two-level key hierarchy. It encrypts each database with an individual key, and puts those keys into a special, so-called "key database". Then, Percona Server for MongoDB uses a master encryption key, provided and managed via the configured key management option, to encrypt the key database. 
 

--- a/docs/lifecycle.md
+++ b/docs/lifecycle.md
@@ -1,0 +1,3 @@
+# Percona Software and Platform Lifecycle
+
+See the [Percona Release Lifecycle Overview](https://www.percona.com/services/policies/percona-software-support-lifecycle#mongodb) for information about support and platform end-of-life dates

--- a/docs/release_notes/lifecycle.md
+++ b/docs/release_notes/lifecycle.md
@@ -1,0 +1,3 @@
+## Percona Software and Platform Lifecycle
+
+See the [Percona Release Lifecycle Overview](https://www.percona.com/services/policies/percona-software-support-lifecycle#mongodb) for information about support and platform end-of-life dates

--- a/docs/release_notes/lifecycle.md
+++ b/docs/release_notes/lifecycle.md
@@ -1,3 +1,3 @@
-## Percona Software and Platform Lifecycle
+# Percona Software and Platform Lifecycle
 
 See the [Percona Release Lifecycle Overview](https://www.percona.com/services/policies/percona-software-support-lifecycle#mongodb) for information about support and platform end-of-life dates

--- a/docs/release_notes/lifecycle.md
+++ b/docs/release_notes/lifecycle.md
@@ -1,3 +1,0 @@
-# Percona Software and Platform Lifecycle
-
-See the [Percona Release Lifecycle Overview](https://www.percona.com/services/policies/percona-software-support-lifecycle#mongodb) for information about support and platform end-of-life dates

--- a/mkdocs-base.yml
+++ b/mkdocs-base.yml
@@ -250,7 +250,6 @@ nav:
       - install/uninstall.md
   - Release notes:
       - "Release notes index": "release_notes/index.md"
-      - release_notes/lifecycle.md
       - release_notes/8.0.19-7.md
       - release_notes/8.0.17-6.md
       - release_notes/8.0.16-5.md
@@ -264,4 +263,5 @@ nav:
       - telemetry.md
       - copyright.md
       - trademark-policy.md 
+  - "Percona Software and Platform Lifecycle": "lifecycle.md"
   - Join Percona Squad: "https://squad.percona.com/mongodb"

--- a/mkdocs-base.yml
+++ b/mkdocs-base.yml
@@ -250,6 +250,7 @@ nav:
       - install/uninstall.md
   - Release notes:
       - "Release notes index": "release_notes/index.md"
+      - release_notes/lifecycle.md
       - release_notes/8.0.19-7.md
       - release_notes/8.0.17-6.md
       - release_notes/8.0.16-5.md


### PR DESCRIPTION
Clarified language regarding data at rest encryption and key management in Percona Server for MongoDB documentation.
Adding new subsection for support policies