### PR TITLE
Update documentation for Percona Memory Engine

### DIFF
--- a/docs/inmemory.md
+++ b/docs/inmemory.md
@@ -8,11 +8,11 @@ memory to hold the data set, and ensure that the server does not shut down.
 The Percona Memory Engine is available in Percona Server for MongoDB, along with the default MongoDB
 engine WiredTiger.
 
-# Usage
+## Usage
 
 Percona Server for MongoDB runs with WiredTiger by default. You can select a
 storage engine using the `--storageEngine` command-line option when you start
-`mongod`. Alternatively, you can set the storage.engine variable in the
+`mongod`. Alternatively, you can set the `storage.engine` variable in the
 configuration file (by default, `/etc/mongod.conf`):
 
 ```yaml
@@ -21,7 +21,7 @@ storage:
   engine: inMemory
 ```
 
-# Configuration
+## Configuration
 
 You can configure Percona Memory Engine using either command-line options or corresponding parameters in the `/etc/mongod.conf` file. 
 
@@ -29,18 +29,18 @@ The following options are available (with corresponding YAML configuration file 
 
 | Configuration file | {{ optionlink('storage.inMemory.engineConfig.inMemorySizeGB') }}|
 |--------------------| ---------------|
-| **Command line**   | `inMemorySizeGB()` |
+| **Command line**   | `--inMemorySizeGB=<value>` |
 | **Default**        | 50% of total memory minus 1024 MB, but not less than 256 MB | 
 | **Description**    | Specifies the maximum memory in gigabytes to use for data |
 
 | Configuration file | {{ optionlink('storage.inMemory.engineConfig.statisticsLogDelaySecs') }}|
 |--------------------| ---------------|
-| **Command line**   | `inMemoryStatisticsLogDelaySecs()()` |
+| **Command line**   | `--inMemoryStatisticsLogDelaySecs=<value>` |
 | **Default**        | 0 | 
 | **Description**    | Specifies the number of seconds between writes to the statistics log.  A 0 value means statistics are not logged |
 
 
-## Examples 
+## Examples
 
 The following are the configuration examples:
 
@@ -57,7 +57,7 @@ The following are the configuration examples:
           statisticsLogDelaySecs: 0
     ```
 
-=== ":material-console: Command line."
+=== ":material-console: Command line"
 
      Setting parameters in the configuration file is the same as
      starting the `mongod` daemon with the following options:
@@ -68,9 +68,9 @@ The following are the configuration examples:
      --inMemoryStatisticsLogDelaySecs=0
      ```
 
-# Switching storage engines
+## Switching storage engines
 
-## Considerations
+### Considerations
 
 If you have data files in your database and want to change to Percona Memory Engine, consider the following:
 

--- a/docs/inmemory.md
+++ b/docs/inmemory.md
@@ -40,7 +40,7 @@ The following options are available (with corresponding YAML configuration file 
 | **Description**    | Specifies the number of seconds between writes to the statistics log.  A 0 value means statistics are not logged |
 
 
-## Examples
+### Examples
 
 The following are the configuration examples:
 
@@ -82,11 +82,11 @@ Creating a new `dbPath` data directory for a different storage engine is the sim
 
 * In addition to running as standalones, `mongod` instances that use Percona Memory Engine storage can run as part of a Replica Set and be part of a sharded cluster.
 
-## Procedure
+### Procedure
 
 To change a storage engine, you have the following options:
 
-### Temporarily test Percona Memory Engine
+#### Temporarily test Percona Memory Engine
   
 Set a different data directory for the `dbPath` variable in the configuration file. Make sure that the user running `mongod` has read and write permissions for the new data directory.
 
@@ -111,7 +111,7 @@ Set a different data directory for the `dbPath` variable in the configuration fi
     ```
 
 
-### Permanent switch to Percona Memory Engine without any valuable data in your database
+#### Permanent switch to Percona Memory Engine without any valuable data in your database
 
 Clean out the `dbPath` data directory (by default, `/var/lib/mongodb`) and edit the configuration file:
 
@@ -141,7 +141,7 @@ Clean out the `dbPath` data directory (by default, `/var/lib/mongodb`) and edit 
     service mongod start
     ```
 
-### Switch to Percona Memory Engine with data migration and compatibility
+#### Switch to Percona Memory Engine with data migration and compatibility
 
 === "Standalone or single-node Replica Set"
 
@@ -217,7 +217,7 @@ Clean out the `dbPath` data directory (by default, `/var/lib/mongodb`) and edit 
     3. Repeat the procedure to switch the remaining nodes to Percona Memory Engine.
 
 
-# Data at rest encryption
+## Data at rest encryption
 
 Using [Data at Rest Encryption](data-at-rest-encryption.md) means using the same `storage.\*`
 configuration options as for [WiredTiger](https://docs.mongodb.org/manual/core/wiredtiger/). To change from normal to [Data at Rest Encryption](data-at-rest-encryption.md) mode or backward, you must clean up the `dbPath` data directory, just as if you change the storage engine. This is because `mongod` cannot convert the data files to an encrypted format **in place**. It

--- a/docs/inmemory.md
+++ b/docs/inmemory.md
@@ -5,13 +5,14 @@ not store user data on disk. Data fully resides in the main memory, making
 processing much faster and smoother. Keep in mind that you need to have enough
 memory to hold the data set, and ensure that the server does not shut down.
 
-The Percona Memory Engine is available in Percona Server for MongoDB along with the default MongoDB engine [WiredTiger](https://docs.mongodb.org/manual/core/wiredtiger/).
+The Percona Memory Engine is available in Percona Server for MongoDB, along with the default MongoDB
+engine WiredTiger.
 
-## Usage
+# Usage
 
-As of version 3.2, Percona Server for MongoDB runs with [WiredTiger](https://docs.mongodb.org/manual/core/wiredtiger/) by default. You can select a
+Percona Server for MongoDB runs with WiredTiger by default. You can select a
 storage engine using the `--storageEngine` command-line option when you start
-`mongod`.  Alternatively, you can set the `storage.engine` variable in the
+`mongod`. Alternatively, you can set the storage.engine variable in the
 configuration file (by default, `/etc/mongod.conf`):
 
 ```yaml
@@ -20,10 +21,28 @@ storage:
   engine: inMemory
 ```
 
-## Configuration
+# Configuration
 
-You can configure Percona Memory Engine using either command-line options or
-corresponding parameters in the `/etc/mongod.conf` file. The following are the configuration examples:
+You can configure Percona Memory Engine using either command-line options or corresponding parameters in the `/etc/mongod.conf` file. 
+
+The following options are available (with corresponding YAML configuration file parameters):
+
+| Configuration file | {{ optionlink('storage.inMemory.engineConfig.inMemorySizeGB') }}|
+|--------------------| ---------------|
+| **Command line**   | `inMemorySizeGB()` |
+| **Default**        | 50% of total memory minus 1024 MB, but not less than 256 MB | 
+| **Description**    | Specifies the maximum memory in gigabytes to use for data |
+
+| Configuration file | {{ optionlink('storage.inMemory.engineConfig.statisticsLogDelaySecs') }}|
+|--------------------| ---------------|
+| **Command line**   | `inMemoryStatisticsLogDelaySecs()()` |
+| **Default**        | 0 | 
+| **Description**    | Specifies the number of seconds between writes to the statistics log.  A 0 value means statistics are not logged |
+
+
+## Examples 
+
+The following are the configuration examples:
 
 === ":octicons-file-code-24: Configuration file"
     
@@ -38,7 +57,7 @@ corresponding parameters in the `/etc/mongod.conf` file. The following are the c
           statisticsLogDelaySecs: 0
     ```
 
-=== ":material-console: Command line"
+=== ":material-console: Command line."
 
      Setting parameters in the configuration file is the same as
      starting the `mongod` daemon with the following options:
@@ -49,42 +68,25 @@ corresponding parameters in the `/etc/mongod.conf` file. The following are the c
      --inMemoryStatisticsLogDelaySecs=0
      ```
 
-### Options
+# Switching storage engines
 
-The following options are available (with corresponding YAML configuration file
-parameters):
-
-| Configuration file | {{ optionlink('storage.inMemory.engineConfig.inMemorySizeGB') }}|
-|--------------------| ---------------|
-| **Command line**   | `inMemorySizeGB()` |
-| **Default**        | 50% of total memory minus 1024 MB, but not less than 256 MB | 
-| **Description**    | Specifies the maximum memory in gigabytes to use for data |
-
-| Configuration file | {{ optionlink('storage.inMemory.engineConfig.statisticsLogDelaySecs') }}|
-|--------------------| ---------------|
-| **Command line**   | `inMemoryStatisticsLogDelaySecs()()` |
-| **Default**        | 0 | 
-| **Description**    | Specifies the number of seconds between writes to statistics log.  A 0 value means statistics are not logged |
-
-
-## Switching storage engines
-
-### Considerations
+## Considerations
 
 If you have data files in your database and want to change to Percona Memory Engine, consider the following:
 
-
 * Data files created by one storage engine are not compatible with other engines, because each one has its own data model.
 
-* When changing the storage engine, the `mongod` node requires an empty `dbPath` data directory when it is restarted. Though Percona Memory Engine stores all data in memory, some metadata files, diagnostics logs and statistics metrics are still written to disk. This is controlled with the `--inMemoryStatisticsLogDelaySecs` option.
+* When changing the storage engine, the `mongod` node requires an empty `dbPath` data directory when it is restarted. Though Percona Memory Engine stores all data in memory, some metadata files, diagnostics logs, and statistics metrics are still written to disk. This is controlled with the `--inMemoryStatisticsLogDelaySecs` option.
 
 Creating a new `dbPath` data directory for a different storage engine is the simplest solution. Yet when you switch between disk-using storage engines (e.g. from [WiredTiger](https://docs.mongodb.org/manual/core/wiredtiger/) to Percona Memory Engine), you may have to delete the old data if there is not enough disk space for both. Double-check that your backups are solid and/or the replica set nodes are healthy before you switch to the new storage engine.
 
-### Procedure
+* In addition to running as standalones, `mongod` instances that use Percona Memory Engine storage can run as part of a Replica Set and be part of a sharded cluster.
+
+## Procedure
 
 To change a storage engine, you have the following options:
 
-#### Temporarily test Percona Memory Engine
+### Temporarily test Percona Memory Engine
   
 Set a different data directory for the `dbPath` variable in the configuration file. Make sure that the user running `mongod` has read and write permissions for the new data directory.
 
@@ -109,7 +111,7 @@ Set a different data directory for the `dbPath` variable in the configuration fi
     ```
 
 
-#### Permanent switch to Percona Memory Engine without any valuable data in your database
+### Permanent switch to Percona Memory Engine without any valuable data in your database
 
 Clean out the `dbPath` data directory (by default, `/var/lib/mongodb`) and edit the configuration file:
 
@@ -139,9 +141,9 @@ Clean out the `dbPath` data directory (by default, `/var/lib/mongodb`) and edit 
     service mongod start
     ```
 
-#### Switch to Percona Memory Engine with data migration and compatibility
+### Switch to Percona Memory Engine with data migration and compatibility
 
-=== "Standalone instance"
+=== "Standalone or single-node Replica Set"
 
     For a standalone instance or a single-node replica set, use the `mongodump` and `mongorestore` utilities:
 
@@ -178,7 +180,7 @@ Clean out the `dbPath` data directory (by default, `/var/lib/mongodb`) and edit 
         mongorestore <dumpDir>
         ```
 
-=== "Replica set"
+=== "Replica Set"
 
     Use the “rolling restart” process.
 
@@ -215,11 +217,10 @@ Clean out the `dbPath` data directory (by default, `/var/lib/mongodb`) and edit 
     3. Repeat the procedure to switch the remaining nodes to Percona Memory Engine.
 
 
-### Data at rest encryption
+# Data at rest encryption
 
 Using [Data at Rest Encryption](data-at-rest-encryption.md) means using the same `storage.\*`
-configuration options as for [WiredTiger](https://docs.mongodb.org/manual/core/wiredtiger/). To change from normal to [Data at Rest Encryption](data-at-rest-encryption.md) mode or backward, you must clean up the `dbPath` data directory, just as if you change the storage engine. This is because
-**mongod** cannot convert the data files to an encrypted format ‘in place’. It
-must get the document data again either via the initial sync from another
-replica set member, or from imported backup dump.
+configuration options as for [WiredTiger](https://docs.mongodb.org/manual/core/wiredtiger/). To change from normal to [Data at Rest Encryption](data-at-rest-encryption.md) mode or backward, you must clean up the `dbPath` data directory, just as if you change the storage engine. This is because `mongod` cannot convert the data files to an encrypted format **in place**. It
+must get the document data again, either via the initial sync from another
+replica set member or from an imported backup.
 


### PR DESCRIPTION
Updates the Percona Memory Engine documentation page to reorganize sections and expand configuration option coverage.

Changes:

Reworks section structure/headings for Usage, Configuration, and Switching storage engines.
Adds a configuration options table (with defaults/descriptions) and separates out examples.
Tweaks wording around storage engine switching and data-at-rest encryption guidance.