### PR TITLE
PSMDB-1947 LDAP User Cache Refresh options

### DIFF
--- a/docs/authorization.md
+++ b/docs/authorization.md
@@ -123,7 +123,7 @@ For example, to set the number of connections in the pool to 5, use the [setPara
 
 ### LDAP cache refresh parameters
 
-As of version **7.0.17-31**, Percona Server for MongoDB introduces parameters to optimize authentication performance and reduce unnecessary load on the LDAP server. These settings control how cached user information is refreshed, allowing administrators to fine-tune the balance between maintaining up-to-date user data and minimizing LDAP query overhead—especially in high-scale environments with many concurrent users.
+As of version 7.0.17-31, Percona Server for MongoDB introduces parameters to optimize authentication performance and reduce unnecessary load on the LDAP server. These settings control how cached user information is refreshed, allowing administrators to fine-tune the balance between maintaining up-to-date user data and minimizing LDAP query overhead—especially in high-scale environments with many concurrent users.
 
 - `ldapUserCacheRefreshInterval` defines how often (in seconds) the server refreshes cached user information from LDAP **when interval-based refresh is enabled** (see `ldapShouldRefreshUserCacheEntries` below).
 

--- a/docs/authorization.md
+++ b/docs/authorization.md
@@ -129,6 +129,32 @@ As of version **7.0.17-31**, Percona Server for MongoDB introduces parameters to
 
 - `ldapShouldRefreshUserCacheEntries` determines whether the refresh strategy is interval‑based (using `ldapUserCacheRefreshInterval`) or expiration‑based (using `ldapUserCacheInvalidationInterval`, already supported in PSMDB).
 
+You can configure these parameters at runtime, on the command line, or in the configuration file.
+
+=== "Runtime (setParameter)"
+
+     ```{.javascript data-prompt=">"}
+     > db.adminCommand({
+     ...   setParameter: 1,
+     ...   ldapUserCacheRefreshInterval: 300,
+     ...   ldapShouldRefreshUserCacheEntries: true
+     ... })
+     ```
+
+=== "Command line"
+
+     ```bash
+     mongod --setParameter "ldapUserCacheRefreshInterval=300" \
+            --setParameter "ldapShouldRefreshUserCacheEntries=true"
+     ```
+
+=== "Configuration file"
+
+     ```yaml
+     setParameter:
+       ldapUserCacheRefreshInterval: 300
+       ldapShouldRefreshUserCacheEntries: true
+     ```
 ### Support for multiple LDAP servers
 
 As of version 6.0.2-1, you can specify multiple LDAP servers for failover. Percona Server for MongoDB sends bind requests to the first server defined in the list. When this server is down or unavailable, it sends requests to the next server  and so on. Note that Percona Server for MongoDB keeps sending requests to this server even after the unavailable server recovers.

--- a/docs/authorization.md
+++ b/docs/authorization.md
@@ -129,11 +129,14 @@ As of version 7.0.17-31, Percona Server for MongoDB introduces parameters to opt
 
 - `ldapShouldRefreshUserCacheEntries` selects the refresh strategy and has the following semantics:
 
-  - When set to `true`, the server uses **interval-based** refresh. Cached LDAP user entries are proactively refreshed on the schedule defined by `ldapUserCacheRefreshInterval`, regardless of their individual age, until they are explicitly removed or invalidated.
+  - When set to `true`, each cached $`external` user is periodically re-fetched from the LDAP server at the interval defined by `ldapUserCacheRefreshInterval`. The cache is updated only if the user’s roles have changed; otherwise, existing entries remain untouched, ensuring no disruption. If a user no longer exists in LDAP, their cache entry is invalidated individually.
+
   - When set to `false`, all $external users are evicted from the user cache each `ldapUserCacheInvalidationInterval` seconds. This preserves the behavior that existed before `ldapUserCacheRefreshInterval` and `ldapShouldRefreshUserCacheEntries` were introduced.
 
-  The default value is `false` (expiration-based refresh using `ldapUserCacheInvalidationInterval`), to maintain backward-compatible behavior unless interval-based refreshing is explicitly enabled.
-You can configure these parameters at runtime, on the command line, or in the configuration file.
+  The default value is `false` (expiration-based invalidation using `ldapUserCacheInvalidationInterval`), to maintain backward-compatible behavior unless interval-based refreshing is explicitly enabled.
+
+`ldapShouldRefreshUserCacheEntries` can only be set at startup. Interval parameters may be configured both at startup and during runtime.
+
 
 === "Runtime (setParameter)"
 

--- a/docs/authorization.md
+++ b/docs/authorization.md
@@ -120,6 +120,15 @@ For example, to set the number of connections in the pool to 5, use the [setPara
        ldapConnectionPoolSizePerHost: 5
      ```
 
+
+### LDAP cache refresh parameters
+
+As of version **7.0.17-31**, Percona Server for MongoDB introduces parameters to optimize authentication performance and reduce unnecessary load on the LDAP server. These settings control how cached user information is refreshed, allowing administrators to fine-tune the balance between maintaining up-to-date user data and minimizing LDAP query overhead—especially in high-scale environments with many concurrent users.
+
+- `ldapUserCacheRefreshInterval` defines how often (in seconds) the server refreshes cached user information from LDAP.
+
+- `ldapShouldRefreshUserCacheEntries` determines whether the refresh strategy is interval‑based (using `ldapUserCacheRefreshInterval`) or expiration‑based (using `ldapUserCacheInvalidationInterval`, already supported in PSMDB).
+
 ### Support for multiple LDAP servers
 
 As of version 6.0.2-1, you can specify multiple LDAP servers for failover. Percona Server for MongoDB sends bind requests to the first server defined in the list. When this server is down or unavailable, it sends requests to the next server  and so on. Note that Percona Server for MongoDB keeps sending requests to this server even after the unavailable server recovers.

--- a/docs/authorization.md
+++ b/docs/authorization.md
@@ -137,6 +137,8 @@ As of version 7.0.17-31, Percona Server for MongoDB introduces parameters to opt
 
 `ldapShouldRefreshUserCacheEntries` can only be set at startup. Interval parameters may be configured both at startup and during runtime.
 
+!!! note
+    The default value will be changed to **true** in all major versions released after March 1, 2026.
 
 === "Runtime (setParameter)"
 

--- a/docs/authorization.md
+++ b/docs/authorization.md
@@ -129,7 +129,7 @@ As of version 7.0.17-31, Percona Server for MongoDB introduces parameters to opt
 
 - `ldapShouldRefreshUserCacheEntries` selects the refresh strategy and has the following semantics:
 
-      - When set to `true`, each cached $`external` user is periodically re-fetched from the LDAP server at the interval defined by `ldapUserCacheRefreshInterval`. The cache is updated only if the user’s roles have changed; otherwise, existing entries remain untouched, ensuring no disruption. If a user no longer exists in LDAP, their cache entry is invalidated individually.
+      - When set to `true`, each cached `$external` user is periodically re-fetched from the LDAP server at the interval defined by `ldapUserCacheRefreshInterval`. The cache is updated only if the user’s roles have changed; otherwise, existing entries remain untouched, ensuring no disruption. If a user no longer exists in LDAP, their cache entry is invalidated individually.
 
       - When set to `false`, all `$external` users are evicted from the cache at intervals defined by `ldapUserCacheInvalidationInterval`. This preserves the behavior that existed prior to the introduction of `ldapUserCacheRefreshInterval` and `ldapShouldRefreshUserCacheEntries`.
 

--- a/docs/authorization.md
+++ b/docs/authorization.md
@@ -137,8 +137,8 @@ As of version 7.0.17-31, Percona Server for MongoDB introduces parameters to opt
 
   `ldapShouldRefreshUserCacheEntries` can only be set at startup. Interval parameters may be configured both at startup and during runtime.
 
-  !!! note
-  
+  !!! warning
+
       The default value will be changed to **true** in all major versions released after March 1, 2026.
 
 === "Runtime (setParameter)"

--- a/docs/authorization.md
+++ b/docs/authorization.md
@@ -129,17 +129,16 @@ As of version 7.0.17-31, Percona Server for MongoDB introduces parameters to opt
 
 - `ldapShouldRefreshUserCacheEntries` selects the refresh strategy and has the following semantics:
 
-    - When set to `true`, each cached $`external` user is periodically re-fetched from the LDAP server at the interval defined by `ldapUserCacheRefreshInterval`. The cache is updated only if the user’s roles have changed; otherwise, existing entries remain untouched, ensuring no disruption. If a user no longer exists in LDAP, their cache entry is invalidated individually.
+      - When set to `true`, each cached $`external` user is periodically re-fetched from the LDAP server at the interval defined by `ldapUserCacheRefreshInterval`. The cache is updated only if the user’s roles have changed; otherwise, existing entries remain untouched, ensuring no disruption. If a user no longer exists in LDAP, their cache entry is invalidated individually.
 
-    - When set to `false`, all `$external` users are evicted from the cache at intervals defined by `ldapUserCacheInvalidationInterval`. This preserves the behavior that existed prior to the introduction of `ldapUserCacheRefreshInterval` and `ldapShouldRefreshUserCacheEntries`.
+      - When set to `false`, all `$external` users are evicted from the cache at intervals defined by `ldapUserCacheInvalidationInterval`. This preserves the behavior that existed prior to the introduction of `ldapUserCacheRefreshInterval` and `ldapShouldRefreshUserCacheEntries`.
 
-  The default value is `false` (expiration-based invalidation using `ldapUserCacheInvalidationInterval`), to maintain backward-compatible behavior unless interval-based refreshing is explicitly enabled.
+    The default value is `false` (expiration-based invalidation using `ldapUserCacheInvalidationInterval`), to maintain backward-compatible behavior unless interval-based refreshing is explicitly enabled.
 
-  `ldapShouldRefreshUserCacheEntries` can only be set at startup. Interval parameters may be configured both at startup and during runtime.
+    `ldapShouldRefreshUserCacheEntries` can only be set at startup. Interval parameters may be configured both at startup and during runtime.
 
-  !!! warning
-
-      The default value will be changed to **true** in all major versions released after March 1, 2026.
+    !!! warning
+        The default value will be changed to **true** in all major versions released after March 1, 2026.
 
 === "Runtime (setParameter)"
 

--- a/docs/authorization.md
+++ b/docs/authorization.md
@@ -125,10 +125,14 @@ For example, to set the number of connections in the pool to 5, use the [setPara
 
 As of version **7.0.17-31**, Percona Server for MongoDB introduces parameters to optimize authentication performance and reduce unnecessary load on the LDAP server. These settings control how cached user information is refreshed, allowing administrators to fine-tune the balance between maintaining up-to-date user data and minimizing LDAP query overhead—especially in high-scale environments with many concurrent users.
 
-- `ldapUserCacheRefreshInterval` defines how often (in seconds) the server refreshes cached user information from LDAP.
+- `ldapUserCacheRefreshInterval` defines how often (in seconds) the server refreshes cached user information from LDAP **when interval-based refresh is enabled** (see `ldapShouldRefreshUserCacheEntries` below).
 
-- `ldapShouldRefreshUserCacheEntries` determines whether the refresh strategy is interval‑based (using `ldapUserCacheRefreshInterval`) or expiration‑based (using `ldapUserCacheInvalidationInterval`, already supported in PSMDB).
+- `ldapShouldRefreshUserCacheEntries` selects the refresh strategy and has the following semantics:
 
+  - When set to `true`, the server uses **interval-based** refresh. Cached LDAP user entries are proactively refreshed on the schedule defined by `ldapUserCacheRefreshInterval`, regardless of their individual age, until they are explicitly removed or invalidated.
+  - When set to `false`, the server uses **expiration-based** refresh. Cached LDAP user entries are refreshed only when they have expired according to `ldapUserCacheInvalidationInterval` and are subsequently accessed. This preserves the behavior that existed before `ldapUserCacheRefreshInterval` and `ldapShouldRefreshUserCacheEntries` were introduced.
+
+  The default value is `false` (expiration-based refresh using `ldapUserCacheInvalidationInterval`), to maintain backward-compatible behavior unless interval-based refreshing is explicitly enabled.
 You can configure these parameters at runtime, on the command line, or in the configuration file.
 
 === "Runtime (setParameter)"

--- a/docs/authorization.md
+++ b/docs/authorization.md
@@ -129,16 +129,16 @@ As of version 7.0.17-31, Percona Server for MongoDB introduces parameters to opt
 
 - `ldapShouldRefreshUserCacheEntries` selects the refresh strategy and has the following semantics:
 
-  - When set to `true`, each cached $`external` user is periodically re-fetched from the LDAP server at the interval defined by `ldapUserCacheRefreshInterval`. The cache is updated only if the user’s roles have changed; otherwise, existing entries remain untouched, ensuring no disruption. If a user no longer exists in LDAP, their cache entry is invalidated individually.
+    - When set to `true`, each cached $`external` user is periodically re-fetched from the LDAP server at the interval defined by `ldapUserCacheRefreshInterval`. The cache is updated only if the user’s roles have changed; otherwise, existing entries remain untouched, ensuring no disruption. If a user no longer exists in LDAP, their cache entry is invalidated individually.
 
-  - When set to `false`, all $external users are evicted from the user cache each `ldapUserCacheInvalidationInterval` seconds. This preserves the behavior that existed before `ldapUserCacheRefreshInterval` and `ldapShouldRefreshUserCacheEntries` were introduced.
+    - When set to `false`, all `$external` users are evicted from the cache at intervals defined by `ldapUserCacheInvalidationInterval`. This preserves the behavior that existed prior to the introduction of `ldapUserCacheRefreshInterval` and `ldapShouldRefreshUserCacheEntries`.
 
   The default value is `false` (expiration-based invalidation using `ldapUserCacheInvalidationInterval`), to maintain backward-compatible behavior unless interval-based refreshing is explicitly enabled.
 
-`ldapShouldRefreshUserCacheEntries` can only be set at startup. Interval parameters may be configured both at startup and during runtime.
+  `ldapShouldRefreshUserCacheEntries` can only be set at startup. Interval parameters may be configured both at startup and during runtime.
 
-!!! note
-    The default value will be changed to **true** in all major versions released after March 1, 2026.
+  !!! note
+      The default value will be changed to **true** in all major versions released after March 1, 2026.
 
 === "Runtime (setParameter)"
 

--- a/docs/authorization.md
+++ b/docs/authorization.md
@@ -138,6 +138,7 @@ As of version 7.0.17-31, Percona Server for MongoDB introduces parameters to opt
   `ldapShouldRefreshUserCacheEntries` can only be set at startup. Interval parameters may be configured both at startup and during runtime.
 
   !!! note
+  
       The default value will be changed to **true** in all major versions released after March 1, 2026.
 
 === "Runtime (setParameter)"

--- a/docs/authorization.md
+++ b/docs/authorization.md
@@ -145,8 +145,7 @@ As of version 7.0.17-31, Percona Server for MongoDB introduces parameters to opt
      ```{.javascript data-prompt=">"}
      > db.adminCommand({
      ...   setParameter: 1,
-     ...   ldapUserCacheRefreshInterval: 300,
-     ...   ldapShouldRefreshUserCacheEntries: true
+     ...   ldapUserCacheRefreshInterval: 300
      ... })
      ```
 

--- a/docs/authorization.md
+++ b/docs/authorization.md
@@ -130,7 +130,7 @@ As of version 7.0.17-31, Percona Server for MongoDB introduces parameters to opt
 - `ldapShouldRefreshUserCacheEntries` selects the refresh strategy and has the following semantics:
 
   - When set to `true`, the server uses **interval-based** refresh. Cached LDAP user entries are proactively refreshed on the schedule defined by `ldapUserCacheRefreshInterval`, regardless of their individual age, until they are explicitly removed or invalidated.
-  - When set to `false`, the server uses **expiration-based** refresh. Cached LDAP user entries are refreshed only when they have expired according to `ldapUserCacheInvalidationInterval` and are subsequently accessed. This preserves the behavior that existed before `ldapUserCacheRefreshInterval` and `ldapShouldRefreshUserCacheEntries` were introduced.
+  - When set to `false`, all $external users are evicted from the user cache each `ldapUserCacheInvalidationInterval` seconds. This preserves the behavior that existed before `ldapUserCacheRefreshInterval` and `ldapShouldRefreshUserCacheEntries` were introduced.
 
   The default value is `false` (expiration-based refresh using `ldapUserCacheInvalidationInterval`), to maintain backward-compatible behavior unless interval-based refreshing is explicitly enabled.
 You can configure these parameters at runtime, on the command line, or in the configuration file.

--- a/docs/authorization.md
+++ b/docs/authorization.md
@@ -127,6 +127,8 @@ As of version 7.0.17-31, Percona Server for MongoDB introduces parameters to opt
 
 - `ldapUserCacheRefreshInterval` defines how often (in seconds) the server refreshes cached user information from LDAP **when interval-based refresh is enabled** (see `ldapShouldRefreshUserCacheEntries` below).
 
+- `ldapUserCacheInvalidationInterval` controls how long (in seconds) cached LDAP user entries remain valid before they expire and are evicted from the cache. If you do not set this parameter explicitly, Percona Server for MongoDB uses the built-in default for your version. This parameter applies when `ldapShouldRefreshUserCacheEntries` is set to `false`.
+
 - `ldapShouldRefreshUserCacheEntries` selects the refresh strategy and has the following semantics:
 
       - When set to `true`, each cached `$external` user is periodically re-fetched from the LDAP server at the interval defined by `ldapUserCacheRefreshInterval`. The cache is updated only if the user’s roles have changed; otherwise, existing entries remain untouched, ensuring no disruption. If a user no longer exists in LDAP, their cache entry is invalidated individually.


### PR DESCRIPTION
- [x] Document `ldapUserCacheRefreshInterval` parameter
- [x] Document `ldapShouldRefreshUserCacheEntries` parameter with true/false semantics and default
- [x] Add description of `ldapUserCacheInvalidationInterval` (units, what it controls, when it applies)
- [x] Fix runtime example to exclude startup-only `ldapShouldRefreshUserCacheEntries`
- [x] Fix `$external` formatting typo
- [x] Add warning about default value change after March 1, 2026
- [x] Remove bold version formatting to match existing style
- [x] Add configuration examples (runtime, command line, config file)

<!-- START COPILOT CODING AGENT TIPS -->
---

📍 Connect Copilot coding agent with [Jira](https://gh.io/cca-jira-docs), [Azure Boards](https://gh.io/cca-azure-boards-docs) or [Linear](https://gh.io/cca-linear-docs) to delegate work to Copilot in one click without leaving your project management tool.